### PR TITLE
チャット周り UI 回収

### DIFF
--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -2,6 +2,7 @@
 // ? basic
 $basic-white: #ffffff;
 $sub-white: #EFEFEF;
+$light-grey: #f5f5f5;
 $primary-color: #2196F3;
 $secondary-color:#673AB7;
 $tertiary-color: #113bc8;

--- a/src/components/Organisms/Manages/ChangeStatus/JobsCard.vue
+++ b/src/components/Organisms/Manages/ChangeStatus/JobsCard.vue
@@ -129,6 +129,10 @@ section {
       font-weight: bold;
       font-size: 0.8em;
       border-radius: 8px;
+      appearance: none;
+      border: none;
+      transition: .3s;
+      outline: none;
     }
 
     .data-area {

--- a/src/components/Organisms/Manages/UserCard.vue
+++ b/src/components/Organisms/Manages/UserCard.vue
@@ -148,6 +148,10 @@ section {
       font-weight: bold;
       font-size: 0.8em;
       border-radius: 8px;
+      appearance: none;
+      border: none;
+      transition: .3s;
+      outline: none;
     }
     .data-area {
       padding: 3.5rem 0 0 0;

--- a/src/components/Organisms/Users/PostUser.vue
+++ b/src/components/Organisms/Users/PostUser.vue
@@ -143,6 +143,10 @@ export default Vue.extend({
       height: 50px;
       font-weight: bold;
       font-size: 1em;
+      appearance: none;
+      border: none;
+      transition: .3s;
+      outline: none;
     }
   }
 }

--- a/src/views/Chats/Chat.vue
+++ b/src/views/Chats/Chat.vue
@@ -1,41 +1,43 @@
 <template>
-<div class="chat-wrapper">
-  <v-card class="chat-wrapper-card" v-if="loginFlag === true">
-    <div class="card-left">
-      <v-card 
-        elevation="2" 
-        :to="`/chat/${ chatGroup.job.id }`" 
-        v-for="chatGroup in chatGroups" 
-        :key="chatGroup.job.id" 
-        v-bind:class="{ active: isActive, 'text-danger': hasError }"
-        >
-        <div class="chat-group-area">
-          <p>{{ chatGroup.job.jobTitle | truncateDetailTitle }}</p>
-          <!-- <div v-for="myselfUser in myselfUser" :key="myselfUser.id" class="chat-member-name">
-          <div v-for="chatMembar in chatMembers" :key="chatMembar.id" class="chat-member-name">
-            <p>{{ myselfUser.user.userName }}  {{ chatMembar.user.userName }}</p>
+  <div class="wrapper">
+    <v-sheet class="chat-card" v-if="loginFlag === true">
+      <div class="chat-card__left">
+        <div class="title">
+          チャットグループ
+        </div>
+        <v-card 
+          :to="`/chat/${ chatGroup.job.id }`" 
+          v-for="chatGroup in chatGroups" 
+          :key="chatGroup.job.id" 
+          v-bind:class="{ active: isActive, 'text-danger': hasError }"
+          class="group"
+          >
+          <div class="group__area">
+            <p>{{ chatGroup.job.jobTitle | truncateDetailTitle }}</p>
+            <v-row class="row">
+              <label for="name">投稿案件</label>
+              <section>12月12日</section>
+            </v-row>
           </div>
-          </div> -->
-        </div>
-      </v-card>
-    </div>
-      <div class="card-right">
-        <div class="card-right-main" ref="target">
-        </div>
-        <div class="card-right-bottom">
-          <textarea type="text" class="chat-form" name="" maxlength="0" placeholder="チャットグループを選択してください"></textarea>
-          <div class="send-btn-area">
-            <span>
-              <font-awesome-icon icon="paper-plane" class="icon"/>
-            </span>
-          </div>
-        </div>
+        </v-card>
       </div>
-  </v-card>
-    <div v-else>
-      ログインが必要です！
+        <div class="chat-card__right">
+          <div class="main" ref="target">
+          </div>
+          <div class="bottom">
+            <v-row>
+              <textarea type="text" class="chat-form" name="" maxlength="0" placeholder="チャットグループを選択してください"></textarea>
+              <span>
+                <button class="send">送信する</button>
+              </span>
+            </v-row>
+          </div>
+        </div>
+    </v-sheet>
+      <div v-else>
+        ログインが必要です！
+      </div>
     </div>
-  </div>
 </template>
 
 <script>
@@ -97,245 +99,194 @@ export default {
   font-weight: bold;
   text-decoration: underline;
 }
-.chat-wrapper{
+.wrapper{
   width: 90%;
   height: 90vh;
   margin: 0 auto;
   position: relative;
 
-  .chat-wrapper-card {
+  .chat-card {
     @include card-border-color;
-      background-color: $basic-white;
-      width: 100%;
-      border-radius: 20px;
-      margin: 2rem 0rem;
-      padding: 0 0rem;
-      position: absolute;
-      right: 0;
-      height: 93%;
-      background-color: $sub-white;
-      position: relative;
+    background-color: $basic-white;
+    width: 980px;
+    border-radius: 8px;
+    margin: 2rem auto;
+    padding: 0 0rem;
+    position: absolute;
+    right: 0;
+    height: 93%;
+    position: relative;
 
-    .card-left {
-      width: 24%;
+    &__left {
+      width: 285px;
+      background-color: sandybrown;
       height: 100%;
       box-shadow: 5px 0 3px #00000011;
-      border-radius: 20px 0 0px 20px;
+      border-radius: 8px 0 0px 8px;
       font-size: 14px;
       background-color: $basic-white;
       overflow: scroll;
+      z-index: 10;
+      position: relative;
+
+      .title {
+        width: 100%;
+        height: 60px;
+        padding: 1rem 0.6rem;
+        font-size: 0.5em;
+        text-align: left;
+        border-bottom: $card-border-color 1px solid;
+      }
+
+      .group {
+        border-bottom: $card-border-color 1px solid;
+        border-radius: none;
+
+        &__area {
+          width: 90%;
+          height: 102px;
+          margin: 0 auto;
+          padding: 0.7rem 0 0.5rem 0;
+          margin-top: 0.2rem;
+          position: relative;
+
+          .row {
+            padding: 0rem 0 0.5rem 1rem;
+            position: absolute;
+            bottom: 0;
+            width: 100%;
+
+            label {
+              @include box-shadow-btn;
+              @include blue-btn;
+              color: $basic-white;
+              padding: 0.25rem 1.5rem;
+              width: 102px;
+              font-weight: bold;
+              font-size: 0.8em;
+              border-radius: 8px;
+              appearance: none;
+              border: none;
+              transition: .3s;
+              outline: none;
+            }
+
+            section {
+              color: grey;
+              font-size: 12px;
+              margin-left: 5.5rem;
+              position: absolute;
+              right: 0;
+              top: 0;
+            }
+          }
+          p {
+            text-align: left;
+            color: $text-main-color;
+          }
+
+          .chat-member-name {
+            font-size: 12px;
+            color: $text-sub-color;
+          }
+        }
+      }
 
       .router {
         cursor: pointer;
         text-decoration: none;
       }
-
-      .chat-group-area {
-        // border-bottom: 0.5px solid grey;
-        width: 90%;
-        height: 102px;
-        margin: 0 auto;
-        padding: 1rem 0;
-        margin-top: 0.2rem;
-        // background-color: yellow;
-
-        p {
-          text-align: left;
-          color: $text-main-color;
-        }
-
-        .chat-member-name {
-          font-size: 12px;
-          color: $text-sub-color;
-        }
-      }
     }
 
-    .card-right {
-      width: 76%;
+    &__right {
+      width: 71%;
       height: 100%;
-      // background-color: rgba(255, 255, 0, 0.367);
       position: absolute;
       top: 0;
       right: 0;
       border-radius: 0 20px 20px 0;
 
-      .card-right-main {
-        width: calc(100% - 1rem);
+      .main {
         margin-top: 0.5rem;
         height: 85%;
-        width: 92%;
         padding: 1rem 2rem;
         overflow: scroll;
         display: flex;
         flex-direction: column;
-
-        .balloon {
-          margin-bottom: 2em;
-          position: relative;
-        }
-        .balloon:before,.balloon:after {
-          clear: both;
-          content: "";
-          display: block;
-        }
-        .balloon-image-left,.balloon-image-right {
-          width: 68px;
-          height: 68px;
-        }
-        .balloon-image-left {
-          float: left;
-            // margin-right: 20px;
-        }
-        .user-name {
-          width: 30%;
-          padding: 0.2rem 1rem;
-          text-align: left;
-          color: $text-sub-color;
-          font-size: 12px;
-        }
-        .balloon-image-right {
-          float: right;
-        }
-        .balloon-img {
-          @include user-image;
-          width: 70%;
-          height: 70%;
-          border-radius: 50%;
-          margin: 0;
-          background-color: #ffffff;
-        }
-        .balloon-image-description {
-          padding: 5px 0 0;
-          font-size: 10px;
-          text-align: center;
-          background-color: #ffffff;
-        }
-        .balloon-text-right,.balloon-text-left {
-          position: relative;
-          padding: 0.8rem 1.4rem;
-          // border: 1px solid #aaa;
-          border-radius: 10px;
-          max-width: -webkit-calc(100% - 120px);
-          max-width: calc(100% - 120px);
-          display: inline-block;
-          background-color: #ffffff;
-          text-align: left;
-        }
-        .balloon-text-right {
-          float: left;
-        }
-        .balloon p {
-          margin: 0 0 20px;
-        }
-        .balloon p:last-child {
-          margin-bottom: 0;
-        }
-        /* 三角部分 */
-        .balloon-text-right:before {
-          position: absolute;
-          content: '';
-          // border: 10px solid transparent;
-          border-right: 10px solid #aaa;
-          top: 15px;
-          left: -20px;
-        }
-        .balloon-text-right:after {
-          position: absolute;
-          content: '';
-          border: 10px solid transparent;
-          border-right: 10px solid #ffffff;
-          top: 15px;
-          left: -19px;
-        }
-        .balloon-text-left:before {
-          position: absolute;
-          content: '';
-          background-color: #ffffff;
-          border: 10px solid transparent;
-          border-left: 10px solid #aaa;
-          top: 15px;
-          right: -20px;
-        }
-        .balloon-text-left:after {
-          position: absolute;
-          content: '';
-          border: 10px solid transparent;
-          border-left: 10px solid #f2f2f2;
-          top: 15px;
-          right: -19px;
-          background-color: #ffffff;
-        }
+        background-color: $basic-white;
       }
 
-      .card-right-bottom {
+      .bottom {
+        background-color: #f5f5f5;
+        z-index: 10;
         position: absolute;
         bottom: 0;
         right: 0;
         width: 100%;
-        border-radius: 0 0px 20px 0;
+        border-radius: 0 0px 8px 0;
         box-shadow: 0 -3px 2px #00000020;
         padding: 1rem 0 1rem 1rem;
 
         .chat-form {
-          width: 89%;
+          width: 80%;
           border-radius: 8px;
-          height: 80%;
-          padding: 0.5rem;
-          background-color: #DDDDDD;
-          border: none;
+          padding: 1rem;
+          background-color: rgba(128, 128, 128, 0.172);
+          border: $card-border-color 1px solid;
           float: left;
           resize: none;
           outline: none;
+          margin-left: 1rem
         }
 
-        .send-btn-area {
-          font-size: 2rem;
-          margin-top: 0.6rem;
-          color: $primary-color;
-        }
+          .send {
+            @include box-shadow-btn;
+            @include blue-btn;
+            color: $basic-white;
+            padding: 1rem 1rem;
+            font-weight: bold;
+            font-size: 14px;
+            border-radius: 8px;
+            appearance: none;
+            border: none;
+            transition: .3s;
+            outline: none;
+            margin-left: 0.5rem;
+          }
       }
     }
   }
+}
+
+// * v-card の boxshadowを消します
+.v-sheet.v-card:not(.v-sheet--outlined) {
+  box-shadow: none; 
 }
 
 @media screen and (max-width: 1200px) {
-  .chat-wrapper{
-    width: 90%;
-
-    .chat-wrapper-card {
-      .card-left {
-        width: 25%;
-
-      }
-    }
+  .wrapper{
+    width: 100%;
   }
 }
 
-@media screen and (max-width: 900px) {
-  .chat-wrapper{
-    width: 98%;
+@media (max-width: 868px) {
+  .wrapper{
+    .chat-card {
+      width: 95%;
 
-    .chat-wrapper-card {
-      .card-left {
-        width: 31%;
-      }
-    }
-  }
-}
-
-@media (max-width: 768px) {
-  .chat-wrapper{
-    .chat-wrapper-card {
-      .card-left {
+      &__left {
         width: 100%;
 
+        .group__area {
+          padding: 0.7rem 0 0.5rem 1rem;
+          margin: 0;
+        }
+
       }
-      .card-right {
+      &__right {
         display: none;
       }
     }
   }
 }
-
 </style>

--- a/src/views/Chats/ChatDetail.vue
+++ b/src/views/Chats/ChatDetail.vue
@@ -1,53 +1,3 @@
-<template>
-  <div class="chat-wrapper">
-    <v-card class="chat-wrapper-card">
-      <div class="card-left">
-        <v-card  
-          elevation="2" 
-          :to="`/chat/${ chatGroup.job.id }`" 
-          v-for="chatGroup in chatGroups" 
-          :key="chatGroup.job.id" 
-          v-bind:class="{ active: isActive, 'text-danger': hasError }"
-          >
-          <div class="chat-group-area">
-            <p>{{ chatGroup.job.jobTitle | truncateDetailTitle }}</p>
-            <!-- <div v-for="myselfUser in myselfUser" :key="myselfUser.id" class="chat-member-name">
-            <div v-for="chatMembar in chatMembers" :key="chatMembar.id" class="chat-member-name">
-              <p>{{ myselfUser.user.userName }}  {{ chatMembar.user.userName }}</p>
-            </div>
-            </div> -->
-          </div>
-        </v-card>
-      </div>
-      <div class="card-right">
-        <div class="card-right-main" ref="target" v-show="!loading">
-          <div class="balloon" v-for="chat in chats" :key="chat.id">
-            <div class="balloon-image-left">
-              <div class="balloon-img"></div>
-            </div>
-            <div class="user-name">
-              {{ chat.user.userName }}
-            </div>
-            <div class="balloon-text-right">
-              <p>{{ chat.message }}</p>
-            </div>
-          </div>
-        </div>
-      <Loading v-show="loading">
-      </Loading>
-        <div class="card-right-bottom">
-          <textarea type="text" class="chat-form" v-model="chatMessage" name="" maxlength="250" placeholder="メッセージを入力してください"></textarea>
-          <div class="send-btn-area">
-            <span @click="chatCreate">
-              <font-awesome-icon icon="paper-plane" class="icon"/>
-            </span>
-          </div>
-        </div>
-      </div>
-    </v-card>
-  </div>
-</template>
-
 <script>
 import axios from 'axios'
 import Loading from '@/components/Organisms/Commons/Loading/Loading.vue'
@@ -105,7 +55,7 @@ export default {
           chatLog.scrollTop = chatLog.scrollHeight
         }
       })
-    }, 2000)
+    }, 1000)
     // ! チャットのタイトルごとに案件参加者を取得できるようにする
     // * 案件参加者を取得
     axios.get(`http://localhost:8888/api/v1/apply_job/?job_id=${ this.id }&apply_status_id=2`)
@@ -165,6 +115,64 @@ export default {
 }
 </script>
 
+<template>
+  <div class="wrapper">
+    <v-sheet class="chat-card">
+      <div class="chat-card__left">
+        <div class="title">
+          チャットグループ
+        </div>
+        <v-card 
+          :to="`/chat/${ chatGroup.job.id }`" 
+          v-for="chatGroup in chatGroups" 
+          :key="chatGroup.job.id" 
+          v-bind:class="{ active: isActive, 'text-danger': hasError }"
+          class="group"
+          >
+          <div class="group__area">
+            <p>{{ chatGroup.job.jobTitle | truncateDetailTitle }}</p>
+            <v-row class="row">
+              <label for="name">投稿案件</label>
+              <section>12月12日</section>
+            </v-row>
+            <!-- <div v-for="myselfUser in myselfUser" :key="myselfUser.id" class="chat-member-name">
+            <div v-for="chatMembar in chatMembers" :key="chatMembar.id" class="chat-member-name">
+              <p>{{ myselfUser.user.userName }}  {{ chatMembar.user.userName }}</p>
+            </div>
+            </div> -->
+          </div>
+        </v-card>
+      </div>
+      <div class="chat-card__right">
+        <div class="main" ref="target" v-show="!loading">
+          <div class="balloon" v-for="chat in chats" :key="chat.id">
+            <div class="balloon-image-left">
+              <div class="balloon-img"></div>
+            </div>
+            <div class="user-name">
+              {{ chat.user.userName }}
+            </div>
+            <div class="balloon-text-right">
+              <p>{{ chat.message }}</p>
+            </div>
+          </div>
+        </div>
+      <Loading v-show="loading">
+      </Loading>
+        <div class="bottom">
+          <v-row>
+            <textarea type="text" class="chat-form" v-model="chatMessage" name="" maxlength="250" placeholder="メッセージを入力してください"></textarea>
+            <span @click="chatCreate">
+              <button class="send">送信する</button>
+            </span>
+          </v-row>
+        </div>
+      </div>
+    </v-sheet>
+  </div>
+</template>
+
+
 <style lang="scss" scoped>
 @import '@/assets/scss/_variables.scss';
 
@@ -176,253 +184,310 @@ export default {
   font-weight: bold;
   text-decoration: underline;
 }
-.chat-wrapper{
+.wrapper{
   width: 90%;
   height: 90vh;
   margin: 0 auto;
   position: relative;
 
-  .chat-wrapper-card {
-      @include card-border-color;
-      background-color: $basic-white;
-      width: 100%;
-      border-radius: 20px;
-      margin: 2rem 0rem;
-      padding: 0 0rem;
-      position: absolute;
-      right: 0;
-      height: 93%;
-      background-color: $sub-white;
-      position: relative;
+  .chat-card {
+    @include card-border-color;
+    background-color: $basic-white;
+    width: 980px;
+    border-radius: 8px;
+    margin: 2rem auto;
+    padding: 0 0rem;
+    position: absolute;
+    right: 0;
+    height: 93%;
+    position: relative;
 
-    .card-left {
-      width: 24%;
+    &__left {
+      width: 285px;
+      background-color: sandybrown;
       height: 100%;
       box-shadow: 5px 0 3px #00000011;
-      border-radius: 20px 0 0px 20px;
+      border-radius: 8px 0 0px 8px;
       font-size: 14px;
       background-color: $basic-white;
       overflow: scroll;
       z-index: 10;
+      position: relative;
+
+      .title {
+        width: 100%;
+        height: 60px;
+        padding: 1rem 0.6rem;
+        font-size: 0.5em;
+        text-align: left;
+        border-bottom: $card-border-color 1px solid;
+      }
+
+      .group {
+        border-bottom: $card-border-color 1px solid;
+        border-radius: none;
+
+        &__area {
+          width: 90%;
+          height: 102px;
+          margin: 0 auto;
+          padding: 0.7rem 0 0.5rem 0;
+          margin-top: 0.2rem;
+          position: relative;
+
+          .row {
+            padding: 0rem 0 0.5rem 1rem;
+            position: absolute;
+            bottom: 0;
+
+            label {
+              @include box-shadow-btn;
+              @include blue-btn;
+              color: $basic-white;
+              padding: 0.25rem 1.5rem;
+              width: 102px;
+              font-weight: bold;
+              font-size: 0.8em;
+              border-radius: 8px;
+              appearance: none;
+              border: none;
+              transition: .3s;
+              outline: none;
+            }
+
+            section {
+              color: grey;
+              font-size: 12px;
+              margin-left: 5.5rem;
+              position: absolute;
+              right: 0;
+              top: 0;
+            }
+          }
+          p {
+            text-align: left;
+            color: $text-main-color;
+          }
+
+          .chat-member-name {
+            font-size: 12px;
+            color: $text-sub-color;
+          }
+        }
+      }
 
       .router {
         cursor: pointer;
         text-decoration: none;
       }
-
-      .chat-group-area {
-        width: 90%;
-        height: 102px;
-        margin: 0 auto;
-        // height: 102px;
-        padding: 0.7rem 0 0.5rem 0;
-        margin-top: 0.2rem;
-
-        p {
-          text-align: left;
-          color: $text-main-color;
-        }
-
-        .chat-member-name {
-          font-size: 12px;
-          color: $text-sub-color;
-        }
-      }
     }
 
-    .card-right {
-      width: 76%;
+    &__right {
+      width: 71%;
       height: 100%;
-      // background-color: rgba(255, 255, 0, 0.367);
       position: absolute;
       top: 0;
       right: 0;
       border-radius: 0 20px 20px 0;
 
-      .card-right-main {
+      .main {
         margin-top: 0.5rem;
         height: 85%;
         padding: 1rem 2rem;
         overflow: scroll;
         display: flex;
         flex-direction: column;
-        // align-items: center;
-          .balloon {
-            margin-bottom: 2em;
-            position: relative;
-          }
-          .balloon:before,.balloon:after {
-            clear: both;
-            content: "";
-            display: block;
-          }
-          .balloon-image-left,.balloon-image-right {
-            width: 68px;
-            height: 68px;
-          }
-          .balloon-image-left {
-            float: left;
-              // margin-right: 20px;
-          }
-          .user-name {
-            padding: 0.2rem 1rem;
-            text-align: left;
-            color: $text-sub-color;
-            font-size: 12px;
-          }
-          .balloon-image-right {
-            float: right;
-          }
-          .balloon-img {
-            @include user-image;
-            width: 70%;
-            height: 70%;
-            border-radius: 50%;
-            margin: 0;
-            background-color: #ffffff;
-          }
-          .balloon-image-description {
-            padding: 5px 0 0;
-            font-size: 10px;
-            text-align: center;
-            background-color: #ffffff;
-          }
-          .balloon-text-right,.balloon-text-left {
-            position: relative;
-            padding: 0.8rem 1.4rem;
-            // border: 1px solid #aaa;
-            border-radius: 10px;
-            max-width: -webkit-calc(100% - 120px);
-            max-width: calc(100% - 120px);
-            display: inline-block;
-            background-color: #ffffff;
-            text-align: left;
-          }
-          .balloon-text-right {
-            float: left;
-          }
-          .balloon p {
-            margin: 0 0 20px;
-          }
-          .balloon p:last-child {
-            margin-bottom: 0;
-          }
-          /* 三角部分 */
-          .balloon-text-right:before {
-            position: absolute;
-            content: '';
-            // border: 10px solid transparent;
-            border-right: 10px solid #aaa;
-            top: 15px;
-            left: -20px;
-          }
-          .balloon-text-right:after {
-            position: absolute;
-            content: '';
-            border: 10px solid transparent;
-            border-right: 10px solid #ffffff;
-            top: 15px;
-            left: -19px;
-          }
-          .balloon-text-left:before {
-            position: absolute;
-            content: '';
-            background-color: #ffffff;
-            border: 10px solid transparent;
-            border-left: 10px solid #aaa;
-            top: 15px;
-            right: -20px;
-          }
-          .balloon-text-left:after {
-            position: absolute;
-            content: '';
-            border: 10px solid transparent;
-            border-left: 10px solid #f2f2f2;
-            top: 15px;
-            right: -19px;
-            background-color: #ffffff;
-          }
+        background-color: $basic-white;
       }
 
-      .card-right-bottom {
-        background-color: #ffffff;
+      .bottom {
+        background-color:$light-grey;
         z-index: 10;
         position: absolute;
         bottom: 0;
         right: 0;
         width: 100%;
-        border-radius: 0 0px 20px 0;
+        border-radius: 0 0px 8px 0;
         box-shadow: 0 -3px 2px #00000020;
         padding: 1rem 0 1rem 1rem;
 
         .chat-form {
-          width: 89%;
+          width: 80%;
           border-radius: 8px;
-          height: 80%;
-          padding: 0.5rem;
-          background-color: #DDDDDD;
-          border: none;
+          padding: 1rem;
+          background-color: #ffffff;
+          border: $card-border-color 1px solid;
           float: left;
           resize: none;
           outline: none;
+          margin-left: 1rem
         }
 
-        .send-btn-area {
-          font-size: 2.5rem;
-          color: $primary-color;
-          cursor: pointer;
-        }
+          .send {
+            @include box-shadow-btn;
+            @include blue-btn;
+            color: $basic-white;
+            padding: 1rem 1rem;
+            font-weight: bold;
+            font-size: 14px;
+            border-radius: 8px;
+            appearance: none;
+            border: none;
+            transition: .3s;
+            outline: none;
+            margin-left: 0.5rem;
+          }
       }
     }
   }
 }
+
+// * v-card の boxshadowを消します
+.v-sheet.v-card:not(.v-sheet--outlined) {
+  box-shadow: none; 
+}
+
+// * ここからトーク周り
+.balloon {
+  margin-bottom: 2em;
+  position: relative;
+}
+.balloon:before,.balloon:after {
+  clear: both;
+  content: "";
+  display: block;
+}
+.balloon-image-left,.balloon-image-right {
+  width: 68px;
+  height: 68px;
+}
+.balloon-image-left {
+  float: left;
+  // margin-right: 20px;
+}
+.user-name {
+  padding: 0.2rem 1rem;
+  text-align: left;
+  color: $text-sub-color;
+  font-size: 12px;
+}
+.balloon-image-right {
+  float: right;
+}
+.balloon-img {
+  @include user-image;
+  width: 70%;
+  height: 70%;
+  border-radius: 50%;
+  margin: 0;
+  background-color: #ffffff;
+}
+.balloon-image-description {
+  padding: 5px 0 0;
+  font-size: 10px;
+  text-align: center;
+  background-color: $light-grey;
+}
+.balloon-text-right,.balloon-text-left {
+  position: relative;
+  padding: 0.8rem 1.4rem;
+  // border: 1px solid #aaa;
+  border-radius: 10px;
+  max-width: -webkit-calc(100% - 120px);
+  max-width: calc(100% - 120px);
+  display: inline-block;
+  background-color: $light-grey;
+  text-align: left;
+}
+.balloon-text-right {
+  float: left;
+}
+.balloon p {
+  margin: 0 0 20px;
+}
+.balloon p:last-child {
+  margin-bottom: 0;
+}
+/* 三角部分 */
+.balloon-text-right:before {
+  position: absolute;
+  content: '';
+  // border: 10px solid transparent;
+  border-right: 10px solid #aaa;
+  top: 15px;
+  left: -20px;
+}
+.balloon-text-right:after {
+  position: absolute;
+  content: '';
+  border: 10px solid transparent;
+  border-right: 10px solid$light-grey;
+  top: 15px;
+  left: -19px;
+}
+.balloon-text-left:before {
+  position: absolute;
+  content: '';
+  background-color: $light-grey;
+  border: 10px solid transparent;
+  border-left: 10px solid #aaa;
+  top: 15px;
+  right: -20px;
+}
+.balloon-text-left:after {
+  position: absolute;
+  content: '';
+  border: 10px solid transparent;
+  border-left: 10px solid #f2f2f2;
+  top: 15px;
+  right: -19px;
+  background-color: #ffffff;
+}
+// * ここまでトーク周り
 
 @media screen and (max-width: 1200px) {
-  .chat-wrapper{
-    width: 90%;
-
-    .chat-wrapper-card {
-      .card-left {
-        width: 25%;
-        // background-color: green;
-      }
-    }
+  .wrapper{
+    width: 100%;
   }
 }
 
-@media screen and (max-width: 900px) {
-  .chat-wrapper{
-    width: 98%;
+@media (max-width: 868px) {
+  .wrapper{
+    .chat-card {
+      width: 95%;
 
-    .chat-wrapper-card {
-      .card-left {
-        width: 31%;
-        // background-color: purple;
-      }
-    }
-  }
-}
-
-@media (max-width: 768px) {
-  .chat-wrapper{
-    .chat-wrapper-card {
-      .card-left {
+      &__left {
         display: none;
 
       }
-      .card-right {
+      &__right {
         width: 100%;
         
-        .card-right-main {
+        .main {
           padding: 1rem 0.5rem 1rem 1rem;
         }
 
-        .card-right-bottom 
+        .bottom 
         .chat-form {
-          width: 75%;
+          width: 70%;
         }
       }
     }
+  }
+}
+
+@media (max-width: 500px) {
+  .wrapper .chat-card__right .bottom { 
+    padding: 1rem 0 1rem 0.1rem;
+    .chat-form{
+      width: 65%;
+    }
+  }
+}
+
+@media (max-width: 380px) {
+  .wrapper .chat-card__right .bottom .chat-form{
+    width: 60%;
   }
 }
 </style>

--- a/src/views/Jobs/JobDetail.vue
+++ b/src/views/Jobs/JobDetail.vue
@@ -344,6 +344,10 @@ export default Vue.extend({
   margin-bottom: 0.5rem;
   cursor: pointer;
   border: none;
+  appearance: none;
+  border: none;
+  transition: .3s;
+  outline: none;
 
   &:hover {
     @include btn-hover;


### PR DESCRIPTION
## 概要
チャットを完成させる。

### 関連issue
#45 


### URL / 参照先
> chat
> chat/id

## 画像
<img width="1440" alt="スクリーンショット 2020-12-18 20 15 28" src="https://user-images.githubusercontent.com/56709557/102608959-10dc1980-416e-11eb-91ef-69f63301b88a.png">
<img width="1436" alt="スクリーンショット 2020-12-18 20 16 45" src="https://user-images.githubusercontent.com/56709557/102608967-15a0cd80-416e-11eb-9403-b98f28b0ef6d.png">



## 確認項目
- [ ] PC
- [ ] レスポンシブ

## 途中
- [ ] チャットグループラベル API
- [ ] グループ 最終メッセージ日にち