### PR TITLE
案件投稿のURLをベタがきすると遷移できてしまう

### DIFF
--- a/src/components/Organisms/Jobs/JobCreateCard.vue
+++ b/src/components/Organisms/Jobs/JobCreateCard.vue
@@ -6,7 +6,7 @@ import JobDescriptionInput from '@/components/Atoms/Forms/JobDescriptionInput.vu
 import Session from '@/components/Atoms/Commons/Session.vue'
 import { JobCreateData } from '@/types/job';
 
-type DataType = {
+export type JobCreateSession1 = {
   jobTitle: string | null;
   jobDescription: string | null;
   devStartDate: string | null;
@@ -20,7 +20,7 @@ export default Vue.extend({
     JobDescriptionInput,
     Session
   },
-  data(): DataType {
+  data(): JobCreateSession1 {
     return {
       jobTitle: "",
       devStartDate: "",
@@ -54,8 +54,8 @@ export default Vue.extend({
     // * セッションストレージの値をフォームに格納する
     const jobTitle = sessionStorage.getItem('jobTitle');
     const jobDescription = sessionStorage.getItem('jobDescription');
-    const devStartDateString = sessionStorage.getItem('devStartDateString');
-    const devEndDateString = sessionStorage.getItem('devEndDateString');
+    const devStartDateString = sessionStorage.getItem('devStartDate');
+    const devEndDateString = sessionStorage.getItem('devEndDate');
     this.jobTitle = jobTitle;
     this.devStartDate = devStartDateString;
     this.devEndDate = devEndDateString;
@@ -70,25 +70,18 @@ export default Vue.extend({
           devStartDate: this.devStartDate, //? 開発開始
           devEndDate: this.devEndDate, //? 開発終了
         };
-        if(params.jobTitle == null) {
-          return null
-        } else {
+        console.log(params)
+        if(params.jobTitle) {
           sessionStorage.setItem('jobTitle', params.jobTitle);
-        }
-        if(params.jobDescription == null) {
-          return null
-        } else {
+        } 
+        if(params.jobDescription) {
           sessionStorage.setItem('jobDescription', params.jobDescription);
         }
-        if(params.devStartDate == null) {
-          return null
-        } else {
-          sessionStorage.setItem('devStartDateString', params.devStartDate);
+        if(params.devStartDate) {
+          sessionStorage.setItem('devStartDate', params.devStartDate);
         }
-        if(params.devEndDate == null) {
-          return null
-        } else {
-          sessionStorage.setItem('devEndDateString', params.devEndDate);
+        if(params.devEndDate) {
+          sessionStorage.setItem('devEndDate', params.devEndDate);
         }
       }
     }

--- a/src/components/Organisms/Jobs/JobCreateSkillCard.vue
+++ b/src/components/Organisms/Jobs/JobCreateSkillCard.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import Vue from 'vue';
+import Vue, { PropType }  from 'vue';
 import { API_URL } from '@/master'
 import axios from 'axios'
 import vSelect from 'vue-select'
@@ -28,6 +28,12 @@ export default Vue.extend({
   components: {
     vSelect,
     Session
+  },
+  props: {
+    jobTitle: { type: String as PropType<string>, default: "" },
+    devStartDate: { type: String as PropType<string>, default: "" },
+    devEndDate: { type: String as PropType<string>, default: "" },
+    jobDescription: { type: String as PropType<string>, default: "" },
   },
   data(): DataType {
     return {
@@ -104,29 +110,25 @@ export default Vue.extend({
       for(let d = 0; d < this.selectedSkill.length; d++) {
         skillArray.push({id: this.selectedSkill[d]})
       }
-      // * settion 1のデータを変数に格納する
-      const jobTitle = sessionStorage.getItem('jobTitle');
-      const jobDescription = sessionStorage.getItem('jobDescription');
-      const devStartDateString = sessionStorage.getItem('devStartDateString');
-      const devEndDateString = sessionStorage.getItem('devEndDateString');
 
-      // ! 宣言していない arameter 'str', 'delim' implicitly has an 'any' type.
+      // FIXME:  宣言していない arameter 'str', 'delim' implicitly has an 'any' type.
       // * date型に変換のための data用意
       function toDate (str: any, delim: any) {
         const arr = str.split(delim)
         return new Date(arr[0], arr[1] - 1, arr[2]);
       }
-      // //* 開始日
-      const devStart = devStartDateString
+      
+      //* 開始日
+      const devStart = this.devStartDate
       const devStartDate = toDate(devStart, '-');
       // *終了日
-      const devEnd = devEndDateString
+      const devEnd = this.devEndDate
       const devEndDate = toDate(devEnd, '-');
 
       const params: JobCreateDataComp = {
         userId: this.$store.state.auth.userId, //? ログインUserId
-        jobTitle : jobTitle,  //? タイトル
-        jobDescription: jobDescription, //? 詳細
+        jobTitle : this.jobTitle,  //? タイトル
+        jobDescription: this.jobDescription, //? 詳細
         devStartDate: devStartDate,  //? 開始日
         devEndDate: devEndDate, //? 終了日
         programingLanguage: languageArray,  //? プログラミング言語

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -74,7 +74,7 @@ const routes: Array<RouteConfig> = [
   {
     path: '/job_create/3',
     name: 'JobCreateComplete',
-    component: JobCreateComplete
+    component: JobCreateComplete,
   },
   // * ユーザー
   {

--- a/src/views/Jobs/JobCreateComplete.vue
+++ b/src/views/Jobs/JobCreateComplete.vue
@@ -8,7 +8,7 @@ type DataType = {
   loading: boolean;
 }
 
-export default Vue.extend({ 
+export default Vue.extend({
   components: {
     Loading,
     UserCard,

--- a/src/views/Jobs/JobCreateSkill.vue
+++ b/src/views/Jobs/JobCreateSkill.vue
@@ -2,11 +2,34 @@
 import Vue from 'vue';
 import UserCard from '@/components/Organisms/Manages/UserCard.vue'
 import JobCreateSkillCard from '@/components/Organisms/Jobs/JobCreateSkillCard.vue'
+import { JobCreateSession1 as DateType } from '@/components/Organisms/Jobs/JobCreateCard.vue'
 
 export default Vue.extend({
   components: {
     UserCard,
     JobCreateSkillCard
+  },
+  computed: {
+    isValue() {
+      if(this.jobTitle && this.devStartDate && this.devEndDate) {
+        return true
+      }
+      return false
+    }
+  },
+  data(): DateType {
+    return {
+      jobTitle: "",
+      devStartDate: "",
+      devEndDate: "",
+      jobDescription: "",
+    }
+  },
+  created() {
+    this.jobTitle = sessionStorage.getItem('jobTitle');
+    this.devStartDate = sessionStorage.getItem('devStartDate');
+    this.devEndDate = sessionStorage.getItem('devEndDate');
+    this.jobDescription = sessionStorage.getItem('jobDescription');
   }
 });
 </script>
@@ -14,14 +37,22 @@ export default Vue.extend({
 <template>
   <section>
     <v-container class="wrapper">
-      <v-row>
+      <v-row v-if="isValue">
         <UserCard />
         <v-sheet class="create">
           <v-col>
-            <JobCreateSkillCard />
+            <JobCreateSkillCard 
+              :jobTitle="jobTitle"
+              :devStartDate="jobTitle"
+              :devEndDate="jobTitle"
+              :jobDescription="jobDescription"
+            />
           </v-col>
         </v-sheet>
       </v-row>
+      <v-col class="not-value" v-else>
+        入力されていないものが存在します。
+      </v-col>
     </v-container>
   </section>
 </template>
@@ -37,6 +68,10 @@ export default Vue.extend({
 
   @media screen and (max-width: 1100px) {
     width: 97%;
+  }
+
+  .not-value {
+    min-height: 100vh
   }
 }
 

--- a/src/views/Users/Manages/ManageUserProfileJobs.vue
+++ b/src/views/Users/Manages/ManageUserProfileJobs.vue
@@ -262,6 +262,10 @@ export default Vue.extend({
     width: 80%;
     margin: 0 auto;
 
+    @media screen and (max-width: 480px) {
+      width: 98%;
+    }
+
     &__card {
       margin-left: 1rem;
       width: 500px;

--- a/src/views/Users/Profiles/ProfileUserJobs.vue
+++ b/src/views/Users/Profiles/ProfileUserJobs.vue
@@ -199,6 +199,10 @@ export default Vue.extend({
     width: 80%;
     margin: 0 auto;
 
+    @media screen and (max-width: 480px) {
+      width: 98%;
+    }
+
     &__card {
       margin-left: 1rem;
       width: 500px;


### PR DESCRIPTION
## 概要
案件投稿のURLをベタがきすると遷移できてしまう。

### 関連issue
#108 

### URL / 参照先
> chat create1 & create2 & create3

## 確認項目
- [ ] ベタ書きをする際に、sessionの中に正しい値が入ってなかったら「create/2」に遷移できないこと
- [ ] createする時にsessionの必須値が入力されていなかったら、投稿できないようにすること（おそらく現在もそうなっているだろうが、リファクタリング含め改善）
