### PR TITLE
webpack-bundle-analyzer の 導入

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3858,6 +3858,16 @@
             "path-exists": "^4.0.0"
           }
         },
+        "gzip-size": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
+          "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
+          "dev": true,
+          "requires": {
+            "duplexer": "^0.1.1",
+            "pify": "^4.0.1"
+          }
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3914,6 +3924,12 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         },
         "pkg-dir": {
@@ -3985,6 +4001,27 @@
             "source-map": "^0.6.1",
             "terser": "^4.6.12",
             "webpack-sources": "^1.4.3"
+          }
+        },
+        "webpack-bundle-analyzer": {
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.9.0.tgz",
+          "integrity": "sha512-Ob8amZfCm3rMB1ScjQVlbYYUEJyEjdEtQ92jqiFUYt5VkEeO2v5UMbv49P/gnmCZm3A6yaFQzCBvpZqN4MUsdA==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-walk": "^7.1.1",
+            "bfj": "^6.1.1",
+            "chalk": "^2.4.1",
+            "commander": "^2.18.0",
+            "ejs": "^2.6.1",
+            "express": "^4.16.3",
+            "filesize": "^3.6.1",
+            "gzip-size": "^5.0.0",
+            "lodash": "^4.17.19",
+            "mkdirp": "^0.5.1",
+            "opener": "^1.5.1",
+            "ws": "^6.0.0"
           }
         }
       }
@@ -11325,24 +11362,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
-    },
-    "gzip-size": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
-      "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
-      "dev": true,
-      "requires": {
-        "duplexer": "^0.1.1",
-        "pify": "^4.0.1"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
-        }
-      }
     },
     "handle-thing": {
       "version": "2.0.1",
@@ -20122,6 +20141,66 @@
         }
       }
     },
+    "vue-cli-plugin-webpack-bundle-analyzer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npm.taobao.org/vue-cli-plugin-webpack-bundle-analyzer/download/vue-cli-plugin-webpack-bundle-analyzer-2.0.0.tgz",
+      "integrity": "sha1-Fg+9SSpnO64b46n3FNsSIYZ4+gE=",
+      "dev": true,
+      "requires": {
+        "webpack-bundle-analyzer": "^3.6.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-7.4.1.tgz",
+          "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
+          "dev": true
+        },
+        "acorn-walk": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npm.taobao.org/acorn-walk/download/acorn-walk-7.2.0.tgz?cache=0&sync_timestamp=1597235849011&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Facorn-walk%2Fdownload%2Facorn-walk-7.2.0.tgz",
+          "integrity": "sha1-DeiJpgEgOQmw++B7iTjcIdLpZ7w=",
+          "dev": true
+        },
+        "gzip-size": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npm.taobao.org/gzip-size/download/gzip-size-5.1.1.tgz?cache=0&sync_timestamp=1605524981174&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fgzip-size%2Fdownload%2Fgzip-size-5.1.1.tgz",
+          "integrity": "sha1-y5vuaS+HwGErIyhAqHOQTkwTUnQ=",
+          "dev": true,
+          "requires": {
+            "duplexer": "^0.1.1",
+            "pify": "^4.0.1"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npm.taobao.org/pify/download/pify-4.0.1.tgz",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+          "dev": true
+        },
+        "webpack-bundle-analyzer": {
+          "version": "3.9.0",
+          "resolved": "https://registry.npm.taobao.org/webpack-bundle-analyzer/download/webpack-bundle-analyzer-3.9.0.tgz?cache=0&sync_timestamp=1608133931699&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-bundle-analyzer%2Fdownload%2Fwebpack-bundle-analyzer-3.9.0.tgz",
+          "integrity": "sha1-9vlNsQj7V05BWtMT3kGicH0z7zw=",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-walk": "^7.1.1",
+            "bfj": "^6.1.1",
+            "chalk": "^2.4.1",
+            "commander": "^2.18.0",
+            "ejs": "^2.6.1",
+            "express": "^4.16.3",
+            "filesize": "^3.6.1",
+            "gzip-size": "^5.0.0",
+            "lodash": "^4.17.19",
+            "mkdirp": "^0.5.1",
+            "opener": "^1.5.1",
+            "ws": "^6.0.0"
+          }
+        }
+      }
+    },
     "vue-codemod": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/vue-codemod/-/vue-codemod-0.0.4.tgz",
@@ -20731,41 +20810,6 @@
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
           }
-        }
-      }
-    },
-    "webpack-bundle-analyzer": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.9.0.tgz",
-      "integrity": "sha512-Ob8amZfCm3rMB1ScjQVlbYYUEJyEjdEtQ92jqiFUYt5VkEeO2v5UMbv49P/gnmCZm3A6yaFQzCBvpZqN4MUsdA==",
-      "dev": true,
-      "requires": {
-        "acorn": "^7.1.1",
-        "acorn-walk": "^7.1.1",
-        "bfj": "^6.1.1",
-        "chalk": "^2.4.1",
-        "commander": "^2.18.0",
-        "ejs": "^2.6.1",
-        "express": "^4.16.3",
-        "filesize": "^3.6.1",
-        "gzip-size": "^5.0.0",
-        "lodash": "^4.17.19",
-        "mkdirp": "^0.5.1",
-        "opener": "^1.5.1",
-        "ws": "^6.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-          "dev": true
-        },
-        "acorn-walk": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-          "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "sass": "^1.26.5",
     "typescript": "~3.9.3",
     "vue-cli-plugin-vuetify": "~2.0.7",
+    "vue-cli-plugin-webpack-bundle-analyzer": "~2.0.0",
     "vue-template-compiler": "^2.6.11",
     "vuetify-loader": "^1.3.0"
   },

--- a/src/views/Manages/Manage.vue
+++ b/src/views/Manages/Manage.vue
@@ -39,20 +39,23 @@ export default defineComponent({
       }
     });
 
-    onMounted(() => {
-      // * 管理案件を取得
-      axios.get<ManageJob[]>(`${API_URL}/job/?user_id=${state.userId}`)
-      .then(response => {
+    const getManageJobs = async () => {
+      try { 
+        const response = await axios.get<ManageJob[]>(`${API_URL}/job/?user_id=${state.userId}`) 
         state.manageJobs = response.data
-      })
-      .catch(error =>{
+      } catch (error) {
         console.log(error)
-      })
+      }
+    };
+
+    onMounted(() => {
+      getManageJobs();
     })
 
     return {
       ...toRefs(state),
       isLogin,
+      getManageJobs
     }
   },
 });

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,9 @@
 module.exports = {
+  pluginOptions: {
+    webpackBundleAnalyzer: {
+      openAnalyzer: false
+    }
+  },
   "devServer": {
     "port": 3030,
     "host": "0.0.0.0",


### PR DESCRIPTION
## 概要
vue-cli-plugin-webpack-bundle-analyzerを導入。
バンドルサイズを計測するために、導入する。

## 関連issue
#128 

## 画像
<img width="1432" alt="スクリーンショット 2021-01-02 22 26 42" src="https://user-images.githubusercontent.com/56709557/103470702-d94dae00-4db8-11eb-9e03-4d96ce3a048a.png">
