### PR TITLE
login_name 削除 irst_name, last_name 追加

### DIFF
--- a/src/components/Molecules/Forms/DatePickerArea.vue
+++ b/src/components/Molecules/Forms/DatePickerArea.vue
@@ -16,7 +16,7 @@ export default defineComponent({
     DatePicker,
   },
   props: {
-    value: { type: String as PropType<string>, required: true, defalut: "" },
+    value: { type: String as PropType<string>, defalut: "" },
     name: { type: String as PropType<string>, required: true },
     textLabel: { type: String as PropType<string>, required: true },
     mandatory: {

--- a/src/components/Molecules/Forms/DescriptionArea.vue
+++ b/src/components/Molecules/Forms/DescriptionArea.vue
@@ -32,7 +32,7 @@ export default defineComponent({
     Description,
   },
   props: {
-    value: { type: String as PropType<string>, required: true, defalut: "" },
+    value: { type: String as PropType<string>, defalut: "" },
     name: { type: String as PropType<string>, required: true },
     textLabel: { type: String as PropType<string>, required: true },
     mandatory: {

--- a/src/components/Molecules/Forms/InputArea.vue
+++ b/src/components/Molecules/Forms/InputArea.vue
@@ -9,7 +9,7 @@ import {
 import Input from "@/components/Atoms/Forms/Input.vue";
 
 type Props = {
-  value: string;
+  value: string | null;
   name: string;
   type: string;
   textLabel: string;

--- a/src/components/Molecules/Jobs/RegisteForm.vue
+++ b/src/components/Molecules/Jobs/RegisteForm.vue
@@ -6,12 +6,12 @@ import Email from "@/components/Atoms/Forms/Email.vue";
 import Password from "@/components/Atoms/Forms/Password.vue";
 
 type State = {
-  LoginName: string;
+  email: string;
   LoginPassword: string;
 };
 
 const initialState = (): State => ({
-  LoginName: "",
+  email: "",
   LoginPassword: "",
 });
 
@@ -25,13 +25,13 @@ export default defineComponent({
 
     const register = async () => {
       const params = {
-        LoginName: state.LoginName,
+        email: state.email,
         LoginPassword: state.LoginPassword,
       };
       try {
         const res = await axios.post(`${API_URL}/signup`, params);
         console.log(res);
-        state.LoginName = "";
+        state.email = "";
         state.LoginPassword = "";
       } catch (error) {
         catchError(error);
@@ -50,7 +50,7 @@ export default defineComponent({
   <section>
     <div class="register-form-area">
       <label for="name" class="label">メールアドレス</label>
-      <Email v-model="LoginName" type="text" placeholder="example@teamUp.com" />
+      <Email v-model="email" type="text" placeholder="example@teamUp.com" />
       <label for="name" class="label">パスワード</label>
       <Password v-model="LoginPassword" type="password" />
     </div>

--- a/src/components/Organisms/Commons/Entires/Header.vue
+++ b/src/components/Organisms/Commons/Entires/Header.vue
@@ -12,7 +12,7 @@ type State = {
 
 const initialState = (): State => ({
   userId: Vuex.state.auth.userId,
-  userName: Vuex.state.auth.loginName,
+  userName: Vuex.state.auth.userName,
 });
 
 export default defineComponent({

--- a/src/components/Organisms/Jobs/CardJob.vue
+++ b/src/components/Organisms/Jobs/CardJob.vue
@@ -67,7 +67,7 @@ const useUtils = () => {
         <div class="post-user-image"></div>
         <div class="post-user-name-area">
           <div class="post-user-name">
-            {{ limit(job.user.login_name, 12) }}
+            {{ limit(job.user.user_name, 12) }}
           </div>
         </div>
         <div class="label-area mt-5">

--- a/src/components/Organisms/Jobs/JobDetails/PostUser.vue
+++ b/src/components/Organisms/Jobs/JobDetails/PostUser.vue
@@ -31,7 +31,7 @@ export default defineComponent({
             <div class="user-name-tag">名前</div>
             <router-link :to="`/account/profile/${job.user_id}`">
               <div class="user-name">
-                {{ limit(job.user.login_name, 27) }}
+                {{ limit(job.user.user_name, 27) }}
               </div>
             </router-link>
           </div>

--- a/src/components/Organisms/Manages/ChangeStatus/UserCard.vue
+++ b/src/components/Organisms/Manages/ChangeStatus/UserCard.vue
@@ -52,7 +52,7 @@ export default defineComponent({
           <div class="card__user__image"></div>
           <v-col>
             <div class="card__user__name">
-              {{ limit(user.user.login_name, 26) }}
+              {{ limit(user.user.user_name, 26) }}
             </div>
             <div class="card__user__study">
               {{ day(user.user.learning_start_date, "YYYY年 M月 D日") }}

--- a/src/components/Organisms/Manages/UserCard.vue
+++ b/src/components/Organisms/Manages/UserCard.vue
@@ -12,12 +12,12 @@ type State = {
   manageNum: number;
   favoriteNum: number;
   applyNum: number;
-  loginName: string;
+  userName: string;
 };
 
 const initialState = (): State => ({
   userId: Vuex.state.auth.userId,
-  loginName: Vuex.state.auth.loginName,
+  userName: Vuex.state.auth.userName,
   manageNum: Vuex.state.statusJobs.jobsManageNum,
   favoriteNum: Vuex.state.statusJobs.jobsFavoriteJobsNum,
   applyNum: Vuex.state.statusJobs.jobsApplyNum,
@@ -44,7 +44,7 @@ export default defineComponent({
       <v-col>
         <v-row class="card__top">
           <div class="user-image"></div>
-          <div class="user-name">{{ loginName }}</div>
+          <div class="user-name">{{ userName }}</div>
         </v-row>
         <v-row class="card__center">
           <router-link :to="`/account/profile/${userId}`" class="">

--- a/src/components/Organisms/Modals/Edit/ProfileEditModal.vue
+++ b/src/components/Organisms/Modals/Edit/ProfileEditModal.vue
@@ -35,6 +35,7 @@ export default Vue.extend({
   },
   methods: {
     // * 編集する
+    // TODO: 編集処理 見直し
     profileEdit() {
       // * date型に変換のための data用意
       function toDate(str: any, delim: string) {
@@ -48,12 +49,13 @@ export default Vue.extend({
         id: this.id,
         updated_at: this.userInfo.updated_at,
         user_name: this.userName,
+        first_name: "",
+        last_name: "",
         birthday: this.userInfo.birthday,
         bio: this.bio,
         github_account: this.githubAccount,
         twitter_account: this.twitterAccount,
         learning_start_date: learningStartDate,
-        login_name: this.userInfo.login_name,
         login_password: "password",
         programing_language_ids: [
           {

--- a/src/components/Organisms/Users/PostUser.vue
+++ b/src/components/Organisms/Users/PostUser.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, computed, PropType } from "@vue/composition-api";
+import { defineComponent, PropType } from "@vue/composition-api";
 import { dayJs } from "@/master";
 import { User } from "@/types/index";
 
@@ -19,10 +19,6 @@ export default defineComponent({
   },
   setup: (props: Props, context) => {
     const day = (value: string, format: string) => dayJs(value, format);
-
-    const enabledBtn = computed(() => {
-      return props.myselfFlag ? true : false;
-    });
 
     const twitterTab = () => {
       if (props.user.twitter_account == null) {
@@ -48,7 +44,6 @@ export default defineComponent({
 
     return {
       day,
-      enabledBtn,
       twitterTab,
       gitTab,
       editEmit,
@@ -68,7 +63,7 @@ export default defineComponent({
           <div class="profile-area">
             <v-col class="name-are">
               <div class="user-name">
-                {{ user.login_name }}
+                {{ user.user_name }}
               </div>
             </v-col>
             <v-col class="introduce-area" style="padding: none">
@@ -96,7 +91,7 @@ export default defineComponent({
         </div>
       </v-row>
       <div class="btn-area">
-        <button class="edit-btn" @click="editEmit" v-if="enabledBtn">
+        <button v-if="myselfFlag" class="edit-btn" @click="editEmit">
           編集する
         </button>
       </div>

--- a/src/components/Organisms/Users/UserBasicInfo.vue
+++ b/src/components/Organisms/Users/UserBasicInfo.vue
@@ -1,0 +1,114 @@
+<script lang="ts">
+import {
+  defineComponent,
+  reactive,
+  computed,
+  PropType,
+} from "@vue/composition-api";
+import { User } from "@/types/index";
+import { dayJs } from "@/master";
+
+type State = {
+  passwordModal: boolean;
+};
+
+const initialState = (): State => ({
+  passwordModal: false,
+});
+export default defineComponent({
+  props: {
+    user: { type: Object as PropType<User>, require: true, defalut: {} },
+  },
+  setup: () => {
+    const state = reactive<State>(initialState());
+    const day = (value: string, format: string) => dayJs(value, format);
+
+    const isOpenPassword = computed(() => {
+      return state.passwordModal ? true : false;
+    });
+    const openPassword = () => {
+      state.passwordModal = true;
+    };
+    const closePassword = () => {
+      state.passwordModal = false;
+    };
+    return {
+      day,
+      isOpenPassword,
+      openPassword,
+      closePassword,
+    };
+  },
+});
+</script>
+
+<template>
+  <div>
+    <v-sheet class="card">
+      <div class="d-flex justify-start">
+        <div class="card__area">
+          <label for="name" class="font-weight-bold text-left">姓</label>
+          <p>{{ user.first_name }}</p>
+        </div>
+        <div class="card__area">
+          <label for="name" class="font-weight-bold text-left">姓</label>
+          <p>{{ user.first_name }}</p>
+        </div>
+      </div>
+      <div class="d-flex justify-start">
+        <div class="card__area">
+          <label for="name" class="font-weight-bold text-left">生年月日</label>
+          <p>{{ day(user.birthday, "YYYY年 M月 D日") }}</p>
+        </div>
+        <div class="card__area">
+          <label for="name" class="font-weight-bold text-left"
+            >メールアドレス</label
+          >
+          <p>{{ user.email }}</p>
+        </div>
+      </div>
+      <div>
+        <label for="name" class="font-weight-bold text-left">パスワード</label>
+        <section v-if="!isOpenPassword">
+          <button @click="openPassword" class="password-btn">開く</button>
+          <p>*********</p>
+        </section>
+        <section v-else>
+          <button @click="closePassword" class="password-btn">
+            閉じる
+          </button>
+          <p>{{ user.login_password }}</p>
+        </section>
+      </div>
+    </v-sheet>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import "@/assets/scss/_variables.scss";
+
+.card {
+  border-radius: 4px;
+  padding: 1.5rem 4rem 1rem 4rem;
+  margin-bottom: 2rem;
+  position: relative;
+
+  @media screen and (max-width: $sm) {
+    padding: 1.5rem 1rem;
+  }
+  &__area {
+    width: 50%;
+    position: relative;
+  }
+}
+
+.password-btn {
+  background-color: $error-message-color;
+  color: $white;
+  padding: 0.2rem 0.5rem;
+  border-radius: 8px;
+  font-size: 12px;
+  float: right;
+  outline: none;
+}
+</style>

--- a/src/components/Organisms/Users/UserTabs.vue
+++ b/src/components/Organisms/Users/UserTabs.vue
@@ -1,0 +1,104 @@
+<script lang="ts">
+import {
+  defineComponent,
+  reactive,
+  toRefs,
+  PropType,
+} from "@vue/composition-api";
+
+type State = {
+  tabs: { id: number; tabName: string }[];
+  selfTabs: { id: number; tabName: string }[];
+};
+
+const initialState = (): State => ({
+  tabs: [
+    { id: 0, tabName: "プロフィール" },
+    { id: 1, tabName: "投稿案件" },
+  ],
+  selfTabs: [
+    { id: 0, tabName: "プロフィール" },
+    { id: 1, tabName: "投稿案件" },
+    { id: 2, tabName: "基本情報" },
+  ],
+});
+
+export default defineComponent({
+  props: {
+    myselfFlag: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+      require: true,
+    },
+    currentTab: { type: Number as PropType<number>, default: 0, require: true },
+  },
+  setup: (_, contex) => {
+    const state = reactive<State>(initialState());
+
+    const clickTab = (index: 0 | 1 | 2) => {
+      contex.emit("clickTab", index);
+    };
+
+    return {
+      ...toRefs(state),
+      clickTab,
+    };
+  },
+});
+</script>
+
+<template>
+  <div class="tabs">
+    <div class="btn-container">
+      <template v-if="myselfFlag">
+        <button
+          v-for="(tab, index) in selfTabs"
+          :key="tab.name"
+          :class="{ active: currentTab === index }"
+          @click="clickTab(index)"
+        >
+          {{ tab.tabName }}
+        </button>
+      </template>
+      <template v-else>
+        <button
+          v-for="(tab, index) in tabs"
+          :key="tab.name"
+          :class="{ active: currentTab === index }"
+          @click="clickTab(index)"
+        >
+          {{ tab.tabName }}
+        </button>
+      </template>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import "@/assets/scss/_variables.scss";
+
+.tabs {
+  width: 100%;
+  border-radius: 10px;
+}
+.btn-container {
+  display: flex;
+}
+
+button {
+  color: $text-main-color;
+  text-decoration: none;
+  width: 33.3%;
+  padding: 0.7rem 0;
+}
+
+button.active {
+  font-weight: bold;
+  color: $text-main-color;
+  text-decoration: none;
+  width: 33.3%;
+  padding: 0.7rem 0;
+  border-bottom: $dark-grey 1px solid;
+  background-color: $dark-grey;
+}
+</style>

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -1,6 +1,5 @@
 import {
   reactive,
-  // SetupContext,
   toRefs,
   onMounted,
   // onUnmounted,
@@ -21,6 +20,7 @@ type State = {
   jobs: Job[];
   job: ApplyJob | Job | {};
   manageJobs: ManageJob[];
+  profileJobs: ManageJob[];
   favoriteJobs: Job[];
   loading: boolean;
 };
@@ -30,6 +30,7 @@ const initialState = (): State => ({
   jobs: [],
   job: {},
   manageJobs: [],
+  profileJobs: [],
   favoriteJobs: [],
   loading: true,
 });
@@ -71,6 +72,17 @@ const useJobs = () => {
     }
   };
 
+  const fetchProfileJobs = async (userId: number) => {
+    try {
+      const res = await axios.get<FetchManageJobs>(
+        `${API_URL}/jobs?user_id=${userId}`
+      );
+      state.profileJobs = res.data.response;
+    } catch (error) {
+      catchError(error);
+    }
+  };
+
   const fetchFavoriteJobs = async () => {
     try {
       const res = await axios.get<FetchJobs>(
@@ -94,6 +106,7 @@ const useJobs = () => {
     fetchManageJobs,
     fetchFavoriteJobs,
     fetchJobDetail,
+    fetchProfileJobs,
   };
 };
 

--- a/src/store/modules/auth.ts
+++ b/src/store/modules/auth.ts
@@ -5,32 +5,32 @@ import router from "@/router/index.ts";
 
 interface State {
   userId: number | null;
-  loginName: string;
+  userName: string;
   errorFlag: boolean;
 }
 
 interface LoginData {
-  login_name: string;
+  email: string;
   login_password: string;
 }
 
 const state: State = {
   userId: null,
-  loginName: "",
+  userName: "",
   errorFlag: false,
 };
 
 const getters: GetterTree<State, LoginData> = {
   userId: (state: State) => state.userId,
-  loginName: (state: State) => state.loginName,
+  userName: (state: State) => state.userName,
 };
 
 const mutations: MutationTree<State> = {
   loginUserId(state: State, userId: number) {
     state.userId = userId;
   },
-  loginUserName(state: State, loginName: string) {
-    state.loginName = loginName;
+  loginUserName(state: State, userName: string) {
+    state.userName = userName;
   },
   loginError(state: State, errorFlag: boolean) {
     state.errorFlag = errorFlag;
@@ -41,13 +41,14 @@ const actions: ActionTree<State, LoginData> = {
   // * ログイン
   async login({ commit }, authData: LoginData) {
     const params: LoginData = {
-      login_name: authData.login_name,
+      email: authData.email,
       login_password: authData.login_password,
     };
     try {
       const res = await axios.post(`${API_URL}/login`, params);
+      console.log(res);
       commit("loginUserId", res.data.response.id);
-      commit("loginUserName", res.data.response.login_name);
+      commit("loginUserName", res.data.response.user_name);
       router.push("/jobs");
     } catch (error) {
       const errorFlag = true;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -31,7 +31,9 @@ export type User = {
   github_account: Maybe<string>;
   updatedAt: Date;
   birthday: Date;
-  login_name: string;
+  user_name: string;
+  first_name: string;
+  last_name: string;
   login_password: string;
   user_name: string;
 };

--- a/src/types/params.d.ts
+++ b/src/types/params.d.ts
@@ -48,9 +48,10 @@ export interface RejectParams {
 
 export interface RegisterSessionFirstParams {
   userName: string;
+  lastName: string;
+  firstName: string;
   password: string;
   email: string;
-  nickName: string;
   userBirthday: string;
   learningStartDate: string;
 }
@@ -72,13 +73,14 @@ export interface messageParams {
 export interface EditProfileParams {
   id: number;
   user_name: string;
+  first_name: string;
+  last_name: string;
   learning_start_date: Date;
   bio: Maybe<string>;
   github_account: Maybe<string>;
   twitter_account: Maybe<string>;
   updated_at: Date;
   birthday: Date;
-  login_name: string;
   login_password: string;
   programing_language_ids: {}[];
   programing_framework_ids: {}[];

--- a/src/views/Chats/ChatDetail.vue
+++ b/src/views/Chats/ChatDetail.vue
@@ -155,7 +155,7 @@ export default defineComponent({
                   <div class="balloon-img"></div>
                 </div>
                 <div class="user-name">
-                  {{ chat.user.login_name }}
+                  {{ chat.user.user_name }}
                 </div>
                 <div class="balloon-text-right">
                   <p>{{ chat.message }}</p>

--- a/src/views/Jobs/Jobs.vue
+++ b/src/views/Jobs/Jobs.vue
@@ -588,7 +588,7 @@ export default defineComponent({
             </div>
             <router-link :to="`/account/profile/${jobDetail.user_id}`">
               <div class="post-user-name-area">
-                {{ limit(jobDetail.user.login_name, 55) }}
+                {{ limit(jobDetail.user.user_name, 55) }}
               </div>
             </router-link>
             <div class="tag-area">

--- a/src/views/Manages/Applications/ApplyJobDetail.vue
+++ b/src/views/Manages/Applications/ApplyJobDetail.vue
@@ -40,7 +40,6 @@ export default defineComponent({
     const state = reactive<State>(initialState());
 
     const { fetchJobDetail, job, loading } = useJobs();
-
     fetchJobDetail(props.id);
 
     const breadcrumbs = computed(() => [

--- a/src/views/Manages/Favorites/FavoriteJobDetail.vue
+++ b/src/views/Manages/Favorites/FavoriteJobDetail.vue
@@ -40,8 +40,8 @@ export default defineComponent({
     const state = reactive<State>(initialState());
 
     const { fetchJobDetail, job, loading } = useJobs();
-
     fetchJobDetail(props.id);
+
     const breadcrumbs = computed(() => [
       {
         text: "探す",

--- a/src/views/Users/Logins/Login.vue
+++ b/src/views/Users/Logins/Login.vue
@@ -5,14 +5,14 @@ import Email from "@/components/Atoms/Forms/Email.vue";
 import Password from "@/components/Atoms/Forms/Password.vue";
 
 type State = {
-  LoginName: string;
-  LoginPassword: string;
+  email: string;
+  password: string;
   loginErrorFlag: boolean;
 };
 
 const initialState = (): State => ({
-  LoginName: "",
-  LoginPassword: "",
+  email: "",
+  password: "",
   loginErrorFlag: false,
 });
 
@@ -31,8 +31,8 @@ export default defineComponent({
 
     const login = () => {
       Vuex.dispatch("login", {
-        login_name: state.LoginName,
-        login_password: state.LoginPassword,
+        email: state.email,
+        login_password: state.password,
       });
       setTimeout(() => {
         if (Vuex.state.auth.errorFlag === true) {
@@ -60,7 +60,7 @@ export default defineComponent({
           <br /><br />
           <v-row cols="12" md="4">
             <Email
-              v-model="LoginName"
+              v-model="email"
               placeholder="example@teamUp.com"
               type="text"
             />
@@ -70,7 +70,7 @@ export default defineComponent({
           <label for="name">パスワード</label>
           <br /><br />
           <v-row cols="12" md="4">
-            <Password v-model="LoginPassword" type="password" />
+            <Password v-model="password" type="password" />
           </v-row>
         </div>
         <div class="error-flag" v-if="loginErrorFlag == true">

--- a/src/views/Users/Manages/ManageUserProfile.vue
+++ b/src/views/Users/Manages/ManageUserProfile.vue
@@ -19,6 +19,7 @@ import CardJob from "@/components/Organisms/Jobs/CardJob.vue";
 import { User } from "@/types/index";
 import { API_URL, catchError, m } from "@/master";
 import useJobs from "@/hooks/useJobs";
+import UserTabs from "@/components/Organisms/Users/UserTabs.vue";
 
 type Props = {
   id: number; //? 詳細を見るユーザーのID
@@ -33,7 +34,6 @@ type State = {
   doneStatusFlag: boolean;
   statusId: number;
   currentTab: 0 | 1;
-  tabs: any;
 };
 
 const initialState = (): State => ({
@@ -43,10 +43,6 @@ const initialState = (): State => ({
   doneStatusFlag: false,
   statusId: m.APPLY_STATUS_APPLY,
   currentTab: 0,
-  tabs: [
-    { id: 1, tabName: "プロフィール" },
-    { id: 2, tabName: "投稿案件" },
-  ],
 });
 
 export default defineComponent({
@@ -57,6 +53,7 @@ export default defineComponent({
     StatusChangeBtnArea,
     Breadcrumbs,
     CardJob,
+    UserTabs,
   },
   props: {
     id: { type: Number as PropType<number>, default: 0, require: true },
@@ -88,9 +85,9 @@ export default defineComponent({
       },
     ]);
 
-    const { manageJobs } = useJobs();
+    const { fetchProfileJobs, profileJobs } = useJobs();
+    fetchProfileJobs(props.id);
 
-    // * ユーザー情報取得
     const fetchUser = async () => {
       try {
         const res = await axios.get(`${API_URL}/user/${props.id}`);
@@ -98,6 +95,10 @@ export default defineComponent({
       } catch (error) {
         catchError(error);
       }
+    };
+
+    const clickTabs = (emitValue: 0 | 1) => {
+      state.currentTab = emitValue;
     };
 
     onMounted(() => {
@@ -110,7 +111,8 @@ export default defineComponent({
     return {
       ...toRefs(state),
       breadcrumbs,
-      manageJobs,
+      profileJobs,
+      clickTabs,
     };
   },
 });
@@ -128,18 +130,11 @@ export default defineComponent({
             :myselfFlag="myselfFlag"
           />
           <v-row class="header">
-            <div class="tabs">
-              <div class="btn-container">
-                <button
-                  v-for="(tab, index) in tabs"
-                  :key="tab.name"
-                  :class="{ active: currentTab === index }"
-                  @click="currentTab = index"
-                >
-                  {{ tab.tabName }}
-                </button>
-              </div>
-            </div>
+            <UserTabs
+              :myselfFlag="false"
+              :currentTab="currentTab"
+              @clickTab="clickTabs($event)"
+            />
           </v-row>
         </div>
       </section>
@@ -161,7 +156,7 @@ export default defineComponent({
         <v-row class="jobs">
           <router-link
             :to="`/jobs/${jobs.id}`"
-            v-for="jobs in manageJobs"
+            v-for="jobs in profileJobs"
             :key="jobs.id"
             class="jobs__card"
           >
@@ -214,31 +209,6 @@ export default defineComponent({
 
       .header {
         border-bottom: $dark-grey 2px solid;
-
-        .tabs {
-          width: 100%;
-          border-radius: 10px;
-        }
-        .btn-container {
-          display: flex;
-        }
-
-        button {
-          color: $text-main-color;
-          text-decoration: none;
-          width: 33.3%;
-          padding: 0.7rem 0;
-        }
-
-        button.active {
-          font-weight: bold;
-          color: $text-main-color;
-          text-decoration: none;
-          width: 33.3%;
-          padding: 0.7rem 0;
-          border-bottom: $dark-grey 1px solid;
-          background-color: $dark-grey;
-        }
       }
     }
   }

--- a/src/views/Users/Profiles/ProfileUser.vue
+++ b/src/views/Users/Profiles/ProfileUser.vue
@@ -19,6 +19,8 @@ import CardJob from "@/components/Organisms/Jobs/CardJob.vue";
 import { User } from "@/types/index";
 import Vuex from "@/store/index";
 import useJobs from "@/hooks/useJobs";
+import UserTabs from "@/components/Organisms/Users/UserTabs.vue";
+import UserBasicInfo from "@/components/Organisms/Users/UserBasicInfo.vue";
 
 type Props = {
   id: number;
@@ -29,8 +31,7 @@ type State = {
   userInfo: User | {};
   userId: number;
   modal: boolean;
-  currentTab: 0 | 1;
-  tabs: any;
+  currentTab: 0 | 1 | 2;
 };
 
 const initialState = (): State => ({
@@ -39,10 +40,6 @@ const initialState = (): State => ({
   userId: Vuex.state.auth.userId,
   modal: false,
   currentTab: 0,
-  tabs: [
-    { id: 1, tabName: "プロフィール" },
-    { id: 2, tabName: "投稿案件" },
-  ],
 });
 
 export default defineComponent({
@@ -54,6 +51,8 @@ export default defineComponent({
     IntroduceUser,
     Breadcrumbs,
     CardJob,
+    UserTabs,
+    UserBasicInfo,
   },
   props: {
     id: { type: Number as PropType<number>, default: 0, require: true },
@@ -73,7 +72,8 @@ export default defineComponent({
       },
     ]);
 
-    const { manageJobs } = useJobs();
+    const { fetchProfileJobs, profileJobs } = useJobs();
+    fetchProfileJobs(props.id);
 
     const fetchUser = async () => {
       // * ユーザー情報取得
@@ -112,6 +112,10 @@ export default defineComponent({
       openModal();
     };
 
+    const clickTabs = (emitValue: 0 | 1 | 2) => {
+      state.currentTab = emitValue;
+    };
+
     return {
       ...toRefs(state),
       breadcrumbs,
@@ -120,7 +124,8 @@ export default defineComponent({
       doSend,
       compliteEdit,
       editEmit,
-      manageJobs,
+      profileJobs,
+      clickTabs,
     };
   },
 });
@@ -144,31 +149,24 @@ export default defineComponent({
             :myselfFlag="myselfFlag"
           />
           <v-row class="header">
-            <div class="tabs">
-              <div class="btn-container">
-                <button
-                  v-for="(tab, index) in tabs"
-                  :key="tab.name"
-                  :class="{ active: currentTab === index }"
-                  @click="currentTab = index"
-                >
-                  {{ tab.tabName }}
-                </button>
-              </div>
-            </div>
+            <UserTabs
+              :myselfFlag="myselfFlag"
+              :currentTab="currentTab"
+              @clickTab="clickTabs($event)"
+            />
           </v-row>
         </div>
       </section>
       <template>
         <div v-show="currentTab === 0">
-          <v-col class="skill">
-            <div class="skill__card">
+          <v-col class="area">
+            <div class="area__card">
               <div class="detail-tag">開発スキル</div>
               <SkillUser :user="userInfo" />
             </div>
           </v-col>
-          <v-col class="pr">
-            <div class="pr__card">
+          <v-col class="area">
+            <div class="area__card">
               <div class="detail-tag">自己紹介</div>
               <IntroduceUser :user="userInfo" />
             </div>
@@ -178,7 +176,7 @@ export default defineComponent({
           <v-row class="jobs">
             <router-link
               :to="`/jobs/${jobs.id}`"
-              v-for="jobs in manageJobs"
+              v-for="jobs in profileJobs"
               :key="jobs.id"
               class="jobs__card"
             >
@@ -186,11 +184,21 @@ export default defineComponent({
             </router-link>
           </v-row>
         </div>
+        <template v-if="myselfFlag">
+          <div v-show="currentTab === 2">
+            <v-col class="area">
+              <div class="area__card">
+                <div class="detail-tag">基本情報</div>
+                <UserBasicInfo :user="userInfo" />
+              </div>
+            </v-col>
+          </div>
+        </template>
         <div class="button-area">
           <div v-if="myselfFlag" class="button-action-area">
             <button @click="openModal" class="btn-box-edit">編集する</button>
           </div>
-          <div class="button-action-area" v-else></div>
+          <div class="button-action-area" v-else />
         </div>
       </template>
     </div>
@@ -239,31 +247,6 @@ export default defineComponent({
 
       .header {
         border-bottom: $dark-grey 2px solid;
-
-        .tabs {
-          width: 100%;
-          border-radius: 10px;
-        }
-        .btn-container {
-          display: flex;
-        }
-
-        button {
-          color: $text-main-color;
-          text-decoration: none;
-          width: 33.3%;
-          padding: 0.7rem 0;
-        }
-
-        button.active {
-          font-weight: bold;
-          color: $text-main-color;
-          text-decoration: none;
-          width: 33.3%;
-          padding: 0.7rem 0;
-          border-bottom: $dark-grey 1px solid;
-          background-color: $dark-grey;
-        }
       }
     }
   }
@@ -285,8 +268,8 @@ export default defineComponent({
   }
 }
 
-//* スキル カード
-.detail-wrapper .skill {
+//* カード
+.detail-wrapper .area {
   width: 100%;
 
   &__card {
@@ -294,28 +277,7 @@ export default defineComponent({
     display: flex;
     flex-direction: column;
     text-align: left;
-    margin: 2rem auto 2rem auto;
-
-    @media screen and (max-width: $la) {
-      width: 95%;
-    }
-
-    @media screen and (max-width: $sm) {
-      width: 100%;
-    }
-  }
-}
-
-//* 開発詳細 カード
-.detail-wrapper .pr {
-  width: 100%;
-
-  &__card {
-    width: 75%;
-    display: flex;
-    flex-direction: column;
-    text-align: left;
-    margin: 0rem auto 2rem auto;
+    margin: 1.3rem auto 2rem auto;
 
     @media screen and (max-width: $la) {
       width: 95%;

--- a/src/views/Users/Registers/Register.vue
+++ b/src/views/Users/Registers/Register.vue
@@ -4,7 +4,7 @@ import axios from "axios";
 import { API_URL, catchError } from "@/master";
 
 type DataType = {
-  LoginName: string;
+  email: string;
   LoginPassword: string;
   emailRules: any[];
   show2: boolean;
@@ -14,7 +14,7 @@ type DataType = {
 export default Vue.extend({
   data(): DataType {
     return {
-      LoginName: "",
+      email: "",
       LoginPassword: "",
       show2: true,
       rules: {
@@ -34,7 +34,7 @@ export default Vue.extend({
   methods: {
     register() {
       const params = {
-        LoginName: this.LoginName,
+        email: this.email,
         LoginPassword: this.LoginPassword,
       };
 
@@ -47,7 +47,7 @@ export default Vue.extend({
         .catch((error) => {
           catchError(error);
         });
-      this.LoginName = "";
+      this.email = "";
       this.LoginPassword = "";
     },
   },
@@ -65,7 +65,7 @@ export default Vue.extend({
           <v-row cols="12" md="4">
             <v-text-field
               class="textholder"
-              v-model="LoginName"
+              v-model="email"
               :rules="emailRules"
               label="example@teamup.com"
               required

--- a/src/views/Users/Registers/RegisterStep1.vue
+++ b/src/views/Users/Registers/RegisterStep1.vue
@@ -14,7 +14,8 @@ type Maybe<T> = T | null;
 
 type State = {
   userName: Maybe<string>;
-  nickName: Maybe<string>;
+  lastName: Maybe<string>;
+  firstName: Maybe<string>;
   userBirthday: Maybe<string>;
   learningStartDate: Maybe<string>;
   dialog: boolean;
@@ -24,7 +25,8 @@ type State = {
 
 const initialState = (): State => ({
   userName: "",
-  nickName: "",
+  lastName: "",
+  firstName: "",
   password: "",
   userBirthday: "",
   learningStartDate: "",
@@ -44,13 +46,15 @@ export default defineComponent({
 
     const strageGet = () => {
       const userName = sessionStorage.getItem("userName");
-      const nickName = sessionStorage.getItem("nickName");
+      const lastName = sessionStorage.getItem("lastName");
+      const firstName = sessionStorage.getItem("firstName");
       const email = sessionStorage.getItem("email");
       const password = sessionStorage.getItem("password");
       const userBirthday = sessionStorage.getItem("userBirthday");
       const learningStartDate = sessionStorage.getItem("learningStartDate");
       state.userName = userName;
-      state.nickName = nickName;
+      state.lastName = lastName;
+      state.firstName = firstName;
       state.password = password;
       state.email = email;
       state.userBirthday = userBirthday;
@@ -59,7 +63,8 @@ export default defineComponent({
 
     const isForm = computed(() => {
       return state.userName &&
-        state.nickName &&
+        state.firstName &&
+        state.lastName &&
         state.userBirthday &&
         state.learningStartDate &&
         state.password &&
@@ -71,7 +76,8 @@ export default defineComponent({
     const nextStep2 = () => {
       if (
         state.userName &&
-        state.nickName &&
+        state.firstName &&
+        state.lastName &&
         state.userBirthday &&
         state.learningStartDate &&
         state.password &&
@@ -79,14 +85,16 @@ export default defineComponent({
       ) {
         const params: RegisterSessionFirstParams = {
           userName: state.userName,
-          nickName: state.nickName,
+          lastName: state.lastName,
+          firstName: state.firstName,
           userBirthday: state.userBirthday,
           learningStartDate: state.learningStartDate,
           password: state.password,
           email: state.email,
         };
         sessionStorage.setItem("userName", params.userName);
-        sessionStorage.setItem("nickName", params.nickName);
+        sessionStorage.setItem("lastName", params.firstName);
+        sessionStorage.setItem("firstName", params.firstName);
         sessionStorage.setItem("userBirthday", params.userBirthday);
         sessionStorage.setItem("learningStartDate", params.learningStartDate);
         sessionStorage.setItem("password", params.password);
@@ -122,24 +130,37 @@ export default defineComponent({
             <InputArea
               v-model="userName"
               type="text"
-              name="jobTitle"
-              textLabel="氏名"
+              name="userName"
+              textLabel="ユーザー名"
               :mandatory="true"
               mandatoryText=""
-              placeholder="例) チームアップ 太郎"
+              placeholder="例) TeamUp"
               maxlength="30"
               :remaining="false"
             />
           </div>
           <div class="input-area">
             <InputArea
-              v-model="nickName"
+              v-model="lastName"
               type="text"
-              name="nickName"
-              textLabel="ユーザー名"
+              name="lastName"
+              textLabel="姓"
               :mandatory="true"
               mandatoryText=""
-              placeholder="例) Tarou"
+              placeholder="例) チームアップ"
+              maxlength="30"
+              :remaining="false"
+            />
+          </div>
+          <div class="input-area">
+            <InputArea
+              v-model="firstName"
+              type="text"
+              name="firstName"
+              textLabel="名"
+              :mandatory="true"
+              mandatoryText=""
+              placeholder="例) 太郎"
               maxlength="30"
               :remaining="false"
             />
@@ -151,7 +172,7 @@ export default defineComponent({
               name="email"
               textLabel="メールアドレス"
               :mandatory="true"
-              mandatoryText="ログイン時必要"
+              mandatoryText=""
               placeholder="example@teamUp.com"
               maxlength="100"
               :remaining="false"
@@ -164,7 +185,7 @@ export default defineComponent({
               name="email"
               textLabel="パスワード"
               :mandatory="true"
-              mandatoryText="ログイン時必要"
+              mandatoryText=""
               placeholder="パスワードを入力してください"
               maxlength="100"
               :remaining="false"


### PR DESCRIPTION
## 概要
- login_name 削除 
- first_name, last_name 追加

## 関連issue
issue作ってないです。

## 対応内容
<img width="305" alt="スクリーンショット 2021-04-08 19 45 35" src="https://user-images.githubusercontent.com/56709557/114252748-dbd82900-99e1-11eb-9b1e-c33e36de2a1a.png"><img width="302" alt="スクリーンショット 2021-04-08 19 46 02" src="https://user-images.githubusercontent.com/56709557/114252775-f7433400-99e1-11eb-8d74-2f2c45ef3c29.png">

- [x] user_name に完全移行(login_name 削除)
- [x] first_name, last_name 追加
- [x] ユーザープロフィールにて、自分のプロフィール閲覧の際に、「基本情報」を表示すること