### PR TITLE
詳細画面制御

### DIFF
--- a/src/components/Atoms/Button/FavoriteBtn.vue
+++ b/src/components/Atoms/Button/FavoriteBtn.vue
@@ -49,7 +49,6 @@ export default Vue.extend({
         await $post<FavoriteParams>(`${API_URL}/favorite_job`, params);
         this.flag = false;
       } catch (error) {
-        console.log("sadcasmcmk");
         catchError(error);
       }
     },

--- a/src/components/Atoms/Button/FavoriteBtn.vue
+++ b/src/components/Atoms/Button/FavoriteBtn.vue
@@ -49,6 +49,7 @@ export default Vue.extend({
         await $post<FavoriteParams>(`${API_URL}/favorite_job`, params);
         this.flag = false;
       } catch (error) {
+        console.log("sadcasmcmk");
         catchError(error);
       }
     },

--- a/src/components/Organisms/Commons/Entires/Header.vue
+++ b/src/components/Organisms/Commons/Entires/Header.vue
@@ -56,7 +56,7 @@ export default defineComponent({
                 <v-list style="z-index: 100;">
                   <v-list-item>
                     <router-link
-                      :to="`/account/profile/${userId}`"
+                      :to="`/account/profile/${userId}/detail`"
                       class="menu-list"
                     >
                       <v-list-item-title>

--- a/src/components/Organisms/Commons/Errors/Error.vue
+++ b/src/components/Organisms/Commons/Errors/Error.vue
@@ -1,0 +1,95 @@
+<script lang="ts">
+import { defineComponent } from "@vue/composition-api";
+import {
+  InsidePropsType,
+  OutsidePropsType,
+  PropType,
+} from "@icare-jp/vue-props-type";
+
+const propsOption = {
+  errorNumber: {
+    type: Number as PropType<number>,
+    required: true,
+    default: 400,
+  },
+  title: { type: String as PropType<string>, required: true, default: "" },
+  describe: { type: String as PropType<string>, required: true, default: "" },
+};
+type PropsOption = typeof propsOption;
+export type Error = OutsidePropsType<PropsOption>;
+
+export default defineComponent<InsidePropsType<PropsOption>>({
+  props: propsOption,
+  setup() {
+    return {};
+  },
+});
+</script>
+<template>
+  <div class="app">
+    <div>{{ errorNumber }}</div>
+    <div class="txt">
+      <span>{{ title }}<span class="blink">_</span></span
+      ><br />
+      <span class="message">{{ describe }}</span>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import url("https://fonts.googleapis.com/css?family=Press+Start+2P");
+@import "@/assets/scss/_variables.scss";
+
+$glowSize: 10px;
+
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+* {
+  font-family: "Press Start 2P", cursive;
+  box-sizing: border-box;
+}
+.app {
+  padding: 1rem;
+  background: $white;
+  display: flex;
+  height: 93vh;
+  justify-content: center;
+  align-items: center;
+  color: $primary-color;
+  text-shadow: 0px 0px $glowSize;
+  font-size: 6rem;
+  flex-direction: column;
+  .txt {
+    font-size: 1.8rem;
+  }
+}
+@keyframes blink {
+  0% {
+    opacity: 0;
+  }
+  49% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.blink {
+  animation-name: blink;
+  animation-duration: 1s;
+  animation-iteration-count: infinite;
+}
+
+.message {
+  font-size: 1rem;
+}
+</style>

--- a/src/components/Organisms/Jobs/JobDetails/PostUser.vue
+++ b/src/components/Organisms/Jobs/JobDetails/PostUser.vue
@@ -28,7 +28,7 @@ export default defineComponent({
         <div class="user-profile-area">
           <div class="user-name-are">
             <div class="user-name-tag">名前</div>
-            <router-link :to="`/account/profile/${job.user_id}`">
+            <router-link :to="`/account/profile/${job.user_id}/detail`">
               <div class="user-name">
                 {{ limit(job.user.user_name, 27) }}
               </div>

--- a/src/components/Organisms/Manages/ChangeStatus/JobsCard.vue
+++ b/src/components/Organisms/Manages/ChangeStatus/JobsCard.vue
@@ -62,7 +62,7 @@ export default defineComponent({
           {{ limit(jobTitle, 60) }}
         </v-row>
         <v-row class="card__center">
-          <router-link :to="`/jobs/${jobId}`">
+          <router-link :to="`/jobs/${jobId}/detail`">
             <button class="detail-btn">詳細をみる</button>
           </router-link>
           <v-row class="data-area">

--- a/src/components/Organisms/Manages/UserCard.vue
+++ b/src/components/Organisms/Manages/UserCard.vue
@@ -47,7 +47,7 @@ export default defineComponent({
           <div class="user-name">{{ userName }}</div>
         </v-row>
         <v-row class="card__center">
-          <router-link :to="`/account/profile/${userId}`" class="">
+          <router-link :to="`/account/profile/${userId}/detail`" class="">
             <button class="btn">詳細をみる</button>
           </router-link>
           <v-row class="data-area">

--- a/src/components/Organisms/TopPage/TopPageNewJobCard.vue
+++ b/src/components/Organisms/TopPage/TopPageNewJobCard.vue
@@ -53,7 +53,7 @@ export default defineComponent({
   <section>
     <v-row>
       <router-link
-        :to="`/jobs/${newJob.id}`"
+        :to="`/jobs/${newJob.id}/detail`"
         class="card"
         v-for="newJob in newJobs"
         :key="newJob.id"

--- a/src/components/Organisms/TopPage/TopPageRecommendJobCard.vue
+++ b/src/components/Organisms/TopPage/TopPageRecommendJobCard.vue
@@ -33,7 +33,7 @@ export default Vue.extend({
   <section>
     <!-- 案件カード デスクトップ -->
     <router-link
-      :to="`/jobs/${newJob.id}`"
+      :to="`/jobs/${newJob.id}/detail`"
       class="job-card-desktop"
       v-for="newJob in newJobsDesktop"
       :key="newJob.id"
@@ -87,7 +87,7 @@ export default Vue.extend({
     <v-row :align="align" no-gutters style="height: 150px;">
       <!-- 通常時案件カード -->
       <v-card
-        :to="`/jobs/${newJob.id}`"
+        :to="`/jobs/${newJob.id}/detail`"
         class="job-card"
         v-for="newJob in newJobs"
         :key="newJob.id"

--- a/src/components/Templates/Manages/ApplyFavorite.vue
+++ b/src/components/Templates/Manages/ApplyFavorite.vue
@@ -84,7 +84,7 @@ export default defineComponent<InsidePropsType<PropsOption>>({
           </v-row>
           <v-col>
             <router-link
-              :to="`/manage/${routingParams}/${job.job_id}`"
+              :to="`/manage/${routingParams}/${job.job_id}/detail`"
               v-for="job in jobs"
               :key="job.job_id"
               class="jobs"

--- a/src/components/Templates/Manages/Manage.vue
+++ b/src/components/Templates/Manages/Manage.vue
@@ -61,7 +61,7 @@ export default defineComponent<InsidePropsType<PropsOption>>({
           </v-row>
           <v-col>
             <router-link
-              :to="`/manage/applicant/${job.id}`"
+              :to="`/manage/${job.id}/applicant`"
               v-for="job in jobs"
               :key="job.id"
               class="jobs"

--- a/src/components/Templates/Manages/StatusChanges.vue
+++ b/src/components/Templates/Manages/StatusChanges.vue
@@ -49,42 +49,42 @@ export default defineComponent({
           <v-row class="manage__header">
             <router-link
               v-if="activeCss === 1"
-              :to="`/manage/applicant/${jobId}`"
+              :to="`/manage/${jobId}/applicant`"
               class="router-link-active-click"
             >
               <span>応募者</span>
             </router-link>
             <router-link
               v-else
-              :to="`/manage/applicant/${jobId}`"
+              :to="`/manage/${jobId}/applicant`"
               class="router-link"
             >
               <span>応募者</span>
             </router-link>
             <router-link
               v-if="activeCss === 2"
-              :to="`/manage/participate/${jobId}`"
+              :to="`/manage/${jobId}/participate`"
               class="router-link-active-click"
             >
               <span>参加者</span>
             </router-link>
             <router-link
               v-else
-              :to="`/manage/participate/${jobId}`"
+              :to="`/manage/${jobId}/participate`"
               class="router-link"
             >
               <span>参加者</span>
             </router-link>
             <router-link
               v-if="activeCss === 3"
-              :to="`/manage/reject/${jobId}`"
+              :to="`/manage/${jobId}/reject`"
               class="router-link-active-click"
             >
               <span>拒否者</span>
             </router-link>
             <router-link
               v-else
-              :to="`/manage/reject/${jobId}`"
+              :to="`/manage/${jobId}/reject`"
               class="router-link"
             >
               <span>拒否者</span>
@@ -92,7 +92,7 @@ export default defineComponent({
           </v-row>
           <v-col>
             <router-link
-              :to="`/manage/profile/${jobId}/${user.user_id}/${user.id}`"
+              :to="`/manage/profile/${jobId}/${user.user_id}/${user.id}/detail`"
               v-for="user in users"
               :key="user.id"
               class="users"

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -4,7 +4,7 @@ import {
   onMounted,
   // onUnmounted,
 } from "@vue/composition-api";
-import { $fetch, API_URL, catchError } from "@/master";
+import { $fetch, API_URL, catchError, fetchError } from "@/master";
 import { ManageJob, FavoriteJob, Job } from "@/types/index";
 import { FetchManageJobs, FetchJobs, FetchFavoriteJob } from "@/types/fetch";
 import Vuex from "@/store/index";
@@ -44,6 +44,7 @@ const useJobs = () => {
   const fetchJobDetail = async (jobId: number) => {
     try {
       const res = await $fetch<FetchJobs>(`${API_URL}/job/${jobId}`);
+      fetchError(res.data.status);
       state.job = res.data.response;
       setTimeout(() => {
         state.loading = false;

--- a/src/master.ts
+++ b/src/master.ts
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import axios from "axios";
+import router from "@/router";
 
 //* 応募のステータス
 // 1: 応募
@@ -16,6 +17,12 @@ const APPLY_STATUS_SELF = 4 as const;
 const JOB_STATUS_NEW = 1 as const;
 const JOB_STATUS_ADD = 2 as const;
 
+// * エラーステータス
+const STATUS_BADREQUEST_ERR = "A400" as const;
+const STATUS_UNAUTHORIZED = "A401" as const;
+const STATUS_NOTFOUND_ERR = "A404" as const;
+const STATUS_SERVER_ERR = "A500" as const;
+
 export const m = {
   APPLY_STATUS_APPLY,
   APPLY_STATUS_PARTICIPATE,
@@ -23,6 +30,10 @@ export const m = {
   APPLY_STATUS_SELF,
   JOB_STATUS_NEW,
   JOB_STATUS_ADD,
+  STATUS_BADREQUEST_ERR,
+  STATUS_UNAUTHORIZED,
+  STATUS_NOTFOUND_ERR,
+  STATUS_SERVER_ERR,
 };
 
 export type Md = {
@@ -67,11 +78,26 @@ const $put = axios.put;
 const $delete = axios.delete;
 export { $fetch, $post, $put, $delete };
 
+// TODO: catch error の際のモーダルを作成し、移行する
 const catchError = (error: any) => {
   const { status, statusText } = error.response;
   return console.log(
     `エラーが発生しました。お問合せください。\n HTTP Status: ${status} ${statusText} \n メッセージ: ${error.response.data.message}`
   );
+};
+
+const fetchError = (status: string) => {
+  if (status === m.STATUS_BADREQUEST_ERR) {
+    router.push({ name: "BadRequest" });
+  } else if (status === m.STATUS_NOTFOUND_ERR) {
+    // request api or client url error
+    router.push({ name: "NotFound" });
+  } else if (status === m.STATUS_SERVER_ERR) {
+    router.push({ name: "ServerError" });
+  } else if (status === m.STATUS_UNAUTHORIZED) {
+    router.push({ name: "Unauthorized" });
+  }
+  return;
 };
 
 const truncate = (value: string, num: number) => {
@@ -86,4 +112,4 @@ const dayJs = (value: string, format: string) => {
   return dayjs(value).format(format);
 };
 
-export { catchError, truncate, dayJs };
+export { catchError, fetchError, truncate, dayJs };

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -27,14 +27,32 @@ import ApplyJobDetail from "@/views/Manages/Applications/ApplyJobDetail.vue";
 import Chat from "@/views/Chats/Chat.vue";
 import ChatDetail from "@/views/Chats/ChatDetail.vue";
 import NotFound from "@/views/Commons/Errors/404.vue";
+import ServerError from "@/views/Commons/Errors/500.vue";
+import BadRequest from "@/views/Commons/Errors/400.vue";
+import Unauthorized from "@/views/Commons/Errors/401.vue";
 Vue.use(VueRouter);
 
 const routes: Array<RouteConfig> = [
   // * 共通
   {
     path: "*",
-    name: "notFound",
+    name: "NotFound",
     component: NotFound,
+  },
+  {
+    path: "error",
+    name: "ServerError",
+    component: ServerError,
+  },
+  {
+    path: "error",
+    name: "BadRequest",
+    component: BadRequest,
+  },
+  {
+    path: "error",
+    name: "Unauthorized",
+    component: Unauthorized,
   },
   {
     path: "/",
@@ -53,7 +71,7 @@ const routes: Array<RouteConfig> = [
     component: Jobs,
   },
   {
-    path: "/jobs/:id",
+    path: "/jobs/:id/detail",
     component: JobDetail,
     props: (route) => ({
       id: Number(route.params.id),
@@ -77,7 +95,7 @@ const routes: Array<RouteConfig> = [
   },
   // * ユーザー
   {
-    path: "/account/profile/:id/",
+    path: "/account/profile/:id/detail",
     component: ProfileUser,
     props: (route) => ({
       id: Number(route.params.id),
@@ -85,7 +103,7 @@ const routes: Array<RouteConfig> = [
   },
   // * 管理案件 ユーザー
   {
-    path: "/manage/profile/:jobId/:id/:applyId",
+    path: "/manage/profile/:jobId/:id/:applyId/detail",
     component: ManageUserProfile,
     props: (route) => ({
       id: Number(route.params.id),
@@ -138,21 +156,21 @@ const routes: Array<RouteConfig> = [
   },
   // ? 案件管理詳細
   {
-    path: "/manage/applicant/:id",
+    path: "/manage/:id/applicant",
     component: Applicant,
     props: (route) => ({
       id: Number(route.params.id),
     }),
   },
   {
-    path: "/manage/participate/:id",
+    path: "/manage/:id/participate",
     component: Participate,
     props: (route) => ({
       id: Number(route.params.id),
     }),
   },
   {
-    path: "/manage/reject/:id",
+    path: "/manage/:id/reject",
     component: Reject,
     props: (route) => ({
       id: Number(route.params.id),
@@ -165,7 +183,7 @@ const routes: Array<RouteConfig> = [
     name: "ManageFavorite",
   },
   {
-    path: "/manage/favorite_job/:id/",
+    path: "/manage/favorite_job/:id/detail",
     component: FavoriteJobDetail,
     props: (route) => ({
       id: Number(route.params.id),
@@ -178,7 +196,7 @@ const routes: Array<RouteConfig> = [
     name: "ManageApply",
   },
   {
-    path: "/manage/apply_job/:id/",
+    path: "/manage/apply_job/:id/detail",
     component: ApplyJobDetail,
     props: (route) => ({
       id: Number(route.params.id),

--- a/src/views/Chats/ChatDetail.vue
+++ b/src/views/Chats/ChatDetail.vue
@@ -145,7 +145,7 @@ export default defineComponent({
         </div>
         <div class="chat-card__right">
           <div class="main" ref="target" v-show="!loading">
-            <router-link :to="`/jobs/${clickJobId}`" class="router">
+            <router-link :to="`/jobs/${clickJobId}/detail`" class="router">
               <header class="header">{{ limit(jobTitle, 60) }}</header>
             </router-link>
             <section class="room" ref="root">

--- a/src/views/Commons/About.vue
+++ b/src/views/Commons/About.vue
@@ -582,7 +582,7 @@ export default Vue.extend({
         .top-title {
           margin: 0rem auto;
           text-align: center;
-          width: 80%;
+          width: 90%;
           height: 40%;
 
           &__upper {

--- a/src/views/Commons/Errors/400.vue
+++ b/src/views/Commons/Errors/400.vue
@@ -15,9 +15,9 @@ export default defineComponent({
 <template>
   <div>
     <Error
-      :errorNumber="404"
-      title="ページが存在しません"
-      describe="URLをご確認ください。"
+      :errorNumber="400"
+      title="リクエストに失敗しました"
+      describe="システム管理者にお問い合わせください"
     />
   </div>
 </template>

--- a/src/views/Commons/Errors/401.vue
+++ b/src/views/Commons/Errors/401.vue
@@ -15,9 +15,9 @@ export default defineComponent({
 <template>
   <div>
     <Error
-      :errorNumber="404"
-      title="ページが存在しません"
-      describe="URLをご確認ください。"
+      :errorNumber="401"
+      title="認証に失敗しました"
+      describe="再度ログインをお試しください"
     />
   </div>
 </template>

--- a/src/views/Commons/Errors/500.vue
+++ b/src/views/Commons/Errors/500.vue
@@ -15,9 +15,9 @@ export default defineComponent({
 <template>
   <div>
     <Error
-      :errorNumber="404"
-      title="ページが存在しません"
-      describe="URLをご確認ください。"
+      :errorNumber="500"
+      title="エラーが発生しました"
+      describe="システム管理者にお問い合わせください"
     />
   </div>
 </template>

--- a/src/views/Jobs/JobDetail.vue
+++ b/src/views/Jobs/JobDetail.vue
@@ -37,7 +37,7 @@ export default defineComponent({
     Breadcrumbs,
   },
   props: {
-    id: { type: Number, default: 0 },
+    id: { type: Number, default: 0, required: true },
   },
   setup: (props) => {
     const state = reactive<State>(initialState());

--- a/src/views/Jobs/Jobs.vue
+++ b/src/views/Jobs/Jobs.vue
@@ -488,7 +488,7 @@ export default defineComponent({
         別のキーワードで検索してください。
       </div>
       <router-link
-        :to="`/jobs/${job.id}`"
+        :to="`/jobs/${job.id}/detail`"
         class="router-1"
         v-for="job in displayJobs"
         :key="job.index"
@@ -521,7 +521,7 @@ export default defineComponent({
               </div>
               <template v-else>
                 <div class="top-job-detail-bottom">
-                  <router-link :to="`/manage/applicant/${jobDetail.id}`">
+                  <router-link :to="`/manage/${jobDetail.id}/applicant`">
                     <button class="btn-box-manage">管理画面</button>
                   </router-link>
                   <div class="label-area mt-5">
@@ -552,7 +552,7 @@ export default defineComponent({
             <div class="tag-area">
               投稿者
             </div>
-            <router-link :to="`/account/profile/${jobDetail.user_id}`">
+            <router-link :to="`/account/profile/${jobDetail.user_id}/detail`">
               <div class="post-user-name-area">
                 {{ limit(jobDetail.user.user_name, 55) }}
               </div>

--- a/src/views/Manages/StatusChanges/Applicant.vue
+++ b/src/views/Manages/StatusChanges/Applicant.vue
@@ -49,7 +49,7 @@ export default defineComponent({
       {
         text: "応募者一覧",
         disabled: true,
-        href: `/manage/applicant/${props.id}`,
+        href: `/manage/${props.id}/applicant`,
       },
     ]);
 

--- a/src/views/Manages/StatusChanges/Participate.vue
+++ b/src/views/Manages/StatusChanges/Participate.vue
@@ -49,7 +49,7 @@ export default defineComponent({
       {
         text: "参加者一覧",
         disabled: true,
-        href: `/manage/participate/${props.id}`,
+        href: `/manage/${props.id}/participate`,
       },
     ]);
 

--- a/src/views/Users/Manages/ManageUserProfile.vue
+++ b/src/views/Users/Manages/ManageUserProfile.vue
@@ -77,7 +77,7 @@ export default defineComponent({
       {
         text: "応募者一覧",
         disabled: false,
-        href: `/manage/applicant/${props.jobId}`,
+        href: `/manage/${props.jobId}/applicant`,
       },
       {
         text: "ユーザー詳細",
@@ -155,7 +155,7 @@ export default defineComponent({
       <div v-show="currentTab === 1">
         <v-row class="jobs">
           <router-link
-            :to="`/jobs/${jobs.id}`"
+            :to="`/jobs/${jobs.id}/detail`"
             v-for="jobs in profileJobs"
             :key="jobs.id"
             class="jobs__card"

--- a/src/views/Users/Profiles/ProfileUser.vue
+++ b/src/views/Users/Profiles/ProfileUser.vue
@@ -7,7 +7,7 @@ import {
   computed,
   PropType,
 } from "@vue/composition-api";
-import { API_URL, catchError, $fetch } from "@/master";
+import { API_URL, catchError, fetchError, $fetch } from "@/master";
 import Vuex from "@/store/index";
 import ProfileEditModal from "@/components/Organisms/Modals/Edit/ProfileEditModal.vue";
 import Breadcrumbs from "@/components/Organisms/Commons/Entires/Breadcrumbs.vue";
@@ -81,6 +81,7 @@ export default defineComponent({
       // * ユーザー情報取得
       try {
         const res = await $fetch<FetchUser>(`${API_URL}/user/${props.id}`);
+        fetchError(res.data.status);
         state.userInfo = res.data.response;
       } catch (error) {
         catchError(error);
@@ -177,7 +178,7 @@ export default defineComponent({
         <div v-show="currentTab === 1">
           <v-row class="jobs">
             <router-link
-              :to="`/jobs/${jobs.id}`"
+              :to="`/jobs/${jobs.id}/detail`"
               v-for="jobs in profileJobs"
               :key="jobs.id"
               class="jobs__card"


### PR DESCRIPTION
## 概要
バックエンドの Error ステータスに合わせて画面を表示。

### サンプル
案件詳細のURL `/jobs/9/detail` ※ 9 は props の値(job_id)

**例**
1) `/jobs/900000000/detail` → 500 サーバーエラー
2) `/jobs/9あああ/detail` → 400 リクエスト失敗
3) `/jobs/9０あああ/detailあああ` → 404 ページが存在しない

## 関連issue
#200

## エビデンス
<img width="195" alt="スクリーンショット 2021-05-08 11 27 42" src="https://user-images.githubusercontent.com/56709557/117524360-fd83fa80-aff7-11eb-9790-18ba86fe3726.png"><img width="195" alt="スクリーンショット 2021-05-08 11 35 55" src="https://user-images.githubusercontent.com/56709557/117524374-05439f00-aff8-11eb-95a7-19282d968ace.png"><img width="195" alt="スクリーンショット 2021-05-08 11 26 28" src="https://user-images.githubusercontent.com/56709557/117524405-15f41500-aff8-11eb-8c4f-880fe52019f5.png"><img width="195" alt="スクリーンショット 2021-05-08 11 27 03" src="https://user-images.githubusercontent.com/56709557/117524420-21474080-aff8-11eb-8d48-45eceefb6005.png">

- [ ] response.data.status の値が 400 の際は、「リクエストに失敗」と表示
- [ ] response.data.status の値が 401 の際は、「認証に失敗」と表示
- [ ] response.data.status の値が 404 の際は、「ページが存在しません」と表示
- [ ] client url が 存在しない場合は、「ページが存在しません」と表示
- [ ] response.data.status の値が 500 の際は、「エラーが発生しました」と表示

### 残りタスク
- [ ] 例外処理 `catch` に入った際のエラーモーダル
- [ ] methods post, put, delete 制御
